### PR TITLE
Notifications: App-provided actions before mute actions

### DIFF
--- a/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/notification/LibPebbleNotification.kt
+++ b/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/notification/LibPebbleNotification.kt
@@ -67,10 +67,10 @@ data class LibPebbleNotification(
             }
             return buildList {
                 dismissAction?.let { add(it) }
+                addAll(actions)
+                contentAction?.let { add(it) }
                 muteAction?.let { add(it) }
                 muteChannelAction?.let { add(it) }
-                contentAction?.let { add(it) }
-                addAll(actions)
             }
         }
     }


### PR DESCRIPTION
I personally found it strange that the muting and Open On Phone actions were before the app-provided actions in the list on the watch. This PR rearranges the order in which actions are added to the list.

In the future, I would like "Reply," if present, to always be the second option in the menu, after Dismiss and before other app-provided actions.

Also: How should I test changes to libpebble3 before committing?