### PR TITLE
Add ProtonMail icon support to notification processor

### DIFF
--- a/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/notification/processor/BasicNotificationProcessor.kt
+++ b/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/notification/processor/BasicNotificationProcessor.kt
@@ -78,6 +78,7 @@ fun StatusBarNotification.icon(): TimelineIcon = when(packageName) {
     "kik.android" -> TimelineIcon.NotificationKik
     "com.kakao.talk" -> TimelineIcon.NotificationKakaoTalk
     "com.beeper.android" -> TimelineIcon.GenericSms
+    "ch.protonmail.android" -> TimelineIcon.GenericEmail
 
     else -> when (notification.category) {
         Notification.CATEGORY_EMAIL -> TimelineIcon.GenericEmail


### PR DESCRIPTION
This pull request introduces a small change to the `StatusBarNotification.icon()` method in `BasicNotificationProcessor.kt`. The change adds support for the ProtonMail Android app by mapping its package name (`"ch.protonmail.android"`) to the `TimelineIcon.NotificationGenericEmail` icon, since it doesnt map by category.