### PR TITLE
Allow specifying more properties on the FakeConnectedDevice

### DIFF
--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/connection/FakeLibPebble.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/connection/FakeLibPebble.kt
@@ -314,19 +314,18 @@ class FakeConnectedDevice(
     override val firmwareUpdateState: FirmwareUpdater.FirmwareUpdateStatus,
     override val name: String,
     override val nickname: String?,
-) : ConnectedPebbleDevice {
-    override val runningFwVersion: String = "v1.2.3-core"
-    override val serial: String = "XXXXXXXXXXXX"
-    override val lastConnected: Instant = Instant.DISTANT_PAST
-    override val watchType: WatchHardwarePlatform = WatchHardwarePlatform.CORE_ASTERIX
     override val color: WatchColor = run {
-        val white = Random.nextBoolean()
-        if (white) {
-            WatchColor.Pebble2DuoWhite
-        } else {
-            WatchColor.Pebble2DuoBlack
-        }
-    }
+       val white = Random.nextBoolean()
+       if (white) {
+         WatchColor.Pebble2DuoWhite
+       } else {
+         WatchColor.Pebble2DuoBlack
+       }
+    },
+    override val watchType: WatchHardwarePlatform = WatchHardwarePlatform.CORE_ASTERIX,
+    override val lastConnected: Instant = Instant.DISTANT_PAST, override val serial: String = "XXXXXXXXXXXX",
+    override val runningFwVersion: String = "v1.2.3-core",
+) : ConnectedPebbleDevice {
 
     override fun forget() {}
     override fun setNickname(nickname: String?) {
@@ -361,7 +360,7 @@ class FakeConnectedDevice(
     override val watchInfo: WatchInfo = WatchInfo(
         runningFwVersion = FirmwareVersion.from(runningFwVersion, isRecovery = false, gitHash = "", timestamp = kotlin.time.Instant.DISTANT_PAST)!!,
         recoveryFwVersion = FirmwareVersion.from(runningFwVersion, isRecovery = true, gitHash = "", timestamp = kotlin.time.Instant.DISTANT_PAST)!!,
-        platform = WatchHardwarePlatform.CORE_ASTERIX,
+        platform = watchType,
         bootloaderTimestamp = kotlin.time.Instant.DISTANT_PAST,
         board = "board",
         serial = serial,


### PR DESCRIPTION
Up until now, FakeConnectedDevice hardcoded some values and even determined others at random, which made this class non-deterministic and hard to test. PR moves all of those declarations to the constructor, allowing them to be re-declared if needed.