### PR TITLE
Mark exposed dependencies as api

### DIFF
--- a/libpebble3/build.gradle.kts
+++ b/libpebble3/build.gradle.kts
@@ -143,12 +143,12 @@ kotlin {
             }
         }
         commonMain.dependencies {
-            implementation(libs.coroutines)
+            api(libs.coroutines)
             implementation(libs.serialization)
             implementation(libs.kermit)
             implementation(libs.room.runtime)
             implementation(libs.sqlite.bundled)
-            implementation(libs.kotlinx.io.core)
+            api(libs.kotlinx.io.core)
             implementation(libs.kotlinx.io.okio)
             implementation(libs.okio)
             // Using our forked version (in a submodule) which has a fix for iOS reads not working
@@ -158,7 +158,7 @@ kotlin {
             implementation(libs.ktor.server.core)
             implementation(libs.ktor.server.cio)
             implementation(libs.ktor.server.websockets)
-            implementation(libs.kotlinx.datetime)
+            api(libs.kotlinx.datetime)
             implementation(libs.koin.core)
             implementation(compose.ui)
             implementation(project(":blobannotations"))


### PR DESCRIPTION
Some internal libraries are exposed to the consumers of the LibPebble3, for example various `Instant` objects that are exposed via `KnownPebbleDevice`. These libraries should be marked as `api`, so they are included in the consumer's classpath.