### PR TITLE
Hide to-be-deleted apps from basic info flow

### DIFF
--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/database/dao/LockerEntryDao.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/database/dao/LockerEntryDao.kt
@@ -5,7 +5,6 @@ import androidx.room.Query
 import androidx.room.Transaction
 import io.rebble.libpebblecommon.database.entity.LockerEntry
 import io.rebble.libpebblecommon.database.entity.LockerEntryDao
-import io.rebble.libpebblecommon.locker.AppBasicProperties
 import io.rebble.libpebblecommon.locker.AppType
 import kotlinx.coroutines.flow.Flow
 import kotlin.uuid.Uuid
@@ -39,7 +38,7 @@ interface LockerEntryRealDao : LockerEntryDao {
     )
 
     @Query("""
-        SELECT id, type, title, developerName FROM LockerEntryEntity
+        SELECT id, type, title, developerName FROM LockerEntryEntity WHERE deleted = 0
     """)
     fun getAllBasicInfoFlow(): Flow<List<DbAppBasicProperties>>
 


### PR DESCRIPTION
Not sure if that was intentional on your part or not, but to me it seems like a bug: `getAllBasicInfoFlow()` will also return to-be-deleted apps (with deleted flag set). 

PR adds a filter for that.