### PR TITLE
Notification colors: use old Pebble App colors when possible

### DIFF
--- a/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/notification/processor/BasicNotificationProcessor.kt
+++ b/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/notification/processor/BasicNotificationProcessor.kt
@@ -49,7 +49,8 @@ class BasicNotificationProcessor(
         val body = bigText ?: text ?: ""
         val people = sbn.notification.people()
         val contactKeys = people.asContacts(context.context)
-        val color = sbn.notification.color.takeIf { it != 0 && it != 0xFF000000.toInt() }
+        val color = HardcodedNotificationColors.packageColorMap[sbn.packageName]
+            ?: sbn.notification.color.takeIf { it != 0 && it != 0xFF000000.toInt() }
         val notification = LibPebbleNotification(
             packageName = sbn.packageName,
             uuid = Uuid.random(),

--- a/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/notification/processor/NotificationColors.kt
+++ b/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/notification/processor/NotificationColors.kt
@@ -1,0 +1,39 @@
+package io.rebble.libpebblecommon.notification.processor
+
+object HardcodedNotificationColors {
+    val packageColorMap = mapOf(
+        "com.google.android.gm" to 0xFFFF0000.toInt(),
+        "com.google.android.googlequicksearchbox" to 0xFF0055FF.toInt(),
+        "com.whatsapp" to 0xFF00AA00.toInt(),
+        "com.google.android.talk" to 0xFF00AA55.toInt(),
+        "com.android.vending" to 0xFF00AA55.toInt(),
+        "com.facebook.orca" to 0xFF0055FF.toInt(),
+        "com.android.email" to 0xFFFF5500.toInt(),
+        "com.google.android.calendar" to 0xFF0055FF.toInt(),
+        "org.telegram.messenger" to 0xFF00AAFF.toInt(),
+        "com.facebook.katana" to 0xFF0055AA.toInt(),
+        "com.google.android.apps.messaging" to 0xFF00AAFF.toInt(),
+        "com.hipchat" to 0xFF0055AA.toInt(),
+        "com.skype.raider" to 0xFF00AAFF.toInt(),
+        "com.twitter.android" to 0xFF00AAFF.toInt(),
+        "com.mailboxapp" to 0xFF00AAFF.toInt(),
+        "com.snapchat.android" to 0xFFFFFF55.toInt(),
+        "com.tencent.mm" to 0xFF55AA00.toInt(),
+        "com.viber.voip" to 0xFFAA00FF.toInt(),
+        "com.instagram.android" to 0xFF0055AA.toInt(),
+        "com.google.android.youtube" to 0xFFFF0000.toInt(),
+        "kik.android" to 0xFF00AA00.toInt(),
+        "jp.naver.line.android" to 0xFF00AA00.toInt(),
+        "com.google.android.apps.inbox" to 0xFF0055FF.toInt(),
+        "com.bbm" to 0xFF555555.toInt(),
+        "com.microsoft.office.outlook" to 0xFF0055FF.toInt(),
+        "com.yahoo.mobile.client.android.mail" to 0xFF5500AA.toInt(),
+        "com.kakao.talk" to 0xFFFFFF00.toInt(),
+        "com.getpebble.android.basalt" to 0xFFFF5500.toInt(),
+        "com.amazon.mshop.android.shopping" to 0xFFFFAA00.toInt(),
+        "com.google.android.apps.maps" to 0xFF0055FF.toInt(),
+        "com.google.android.apps.photos" to 0xFF0055FF.toInt(),
+        "com.linkedin.android" to 0xFF0055AA.toInt(),
+        "com.slack" to 0xFFFF0055.toInt()
+    )
+}


### PR DESCRIPTION
Old colors here: https://gist.github.com/KonradIT/5ec62e636d765f70270e09baa1b22e49

Not sure of a way to test this unfortunately. 