### PR TITLE
fix LibPebbleInCallService crash

### DIFF
--- a/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/calls/LibPebbleInCallService.kt
+++ b/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/calls/LibPebbleInCallService.kt
@@ -9,12 +9,12 @@ import android.telecom.InCallService
 import android.telecom.VideoProfile
 import co.touchlab.kermit.Logger
 import io.rebble.libpebblecommon.connection.LibPebble
-import org.koin.core.component.KoinComponent
+import io.rebble.libpebblecommon.di.LibPebbleKoinComponent
 import org.koin.core.component.inject
 import kotlin.random.Random
 import kotlin.random.nextUInt
 
-class LibPebbleInCallService: InCallService(), KoinComponent {
+class LibPebbleInCallService : InCallService(), LibPebbleKoinComponent {
     companion object {
         private val logger = Logger.withTag("LibPebbleInCallService")
     }


### PR DESCRIPTION
Another wrong koin component issue: `LibPebbleInCallService` crashed because global Koin component has no access to the `LibPebble` instance.