### PR TITLE
Notifications: Add hard-coded colors for Discord and Beeper on Android

### DIFF
--- a/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/notification/processor/NotificationColors.kt
+++ b/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/notification/processor/NotificationColors.kt
@@ -34,6 +34,8 @@ object HardcodedNotificationColors {
         "com.google.android.apps.maps" to 0xFF0055FF.toInt(),
         "com.google.android.apps.photos" to 0xFF0055FF.toInt(),
         "com.linkedin.android" to 0xFF0055AA.toInt(),
-        "com.slack" to 0xFFFF0055.toInt()
+        "com.slack" to 0xFFFF0055.toInt(),
+        "com.beeper.android" to 0xAA00FF.toInt(),
+        "com.discord" to 0x5500AA.toInt()
     )
 }


### PR DESCRIPTION
Adds hard-coded notification colors for `com.beeper.android` and `com.discord` on Android. Beeper uses `GColorVividViolet`, and Discord uses `GColorIndigo`. The same change for iOS will need to be done on the firmware side (https://github.com/pebble-dev/pebble-firmware/pull/288)