### PR TITLE
Fixed pair events error

### DIFF
--- a/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/connection/bt/Pairing.android.kt
+++ b/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/connection/bt/Pairing.android.kt
@@ -38,7 +38,7 @@ actual fun getBluetoothDevicePairEvents(
     identifier: PebbleBleIdentifier,
     connectivity: Flow<ConnectivityStatus>,
 ): Flow<BluetoothDevicePairEvent> {
-    return IntentFilter(BluetoothDevice.ACTION_BOND_STATE_CHANGED).asFlow(context.context)
+    return IntentFilter(BluetoothDevice.ACTION_BOND_STATE_CHANGED).asFlow(context.context, exported = true)
         .mapNotNull {
             val device: BluetoothDevice = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                 it.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE, BluetoothDevice::class.java)

--- a/libpebble3/src/androidMain/kotlin/util/BroadcastReceiver.kt
+++ b/libpebble3/src/androidMain/kotlin/util/BroadcastReceiver.kt
@@ -13,11 +13,10 @@ import kotlinx.coroutines.flow.callbackFlow
 /**
  * Consume intents from specific IntentFilter as coroutine flow
  * @param context Context to register the BroadcastReceiver with
- * @param exported Whether the receiver should be exported or not. If null, default system behavior
- * is used.
+ * @param exported Whether the receiver should be exported or not.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
-fun IntentFilter.asFlow(context: Context, exported: Boolean? = null): Flow<Intent> = callbackFlow {
+fun IntentFilter.asFlow(context: Context, exported: Boolean): Flow<Intent> = callbackFlow {
     val receiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context, intent: Intent) {
             trySend(intent).isSuccess
@@ -31,7 +30,6 @@ fun IntentFilter.asFlow(context: Context, exported: Boolean? = null): Flow<Inten
         when (exported) {
             true -> ContextCompat.RECEIVER_EXPORTED
             false -> ContextCompat.RECEIVER_NOT_EXPORTED
-            null -> 0
         },
     )
 


### PR DESCRIPTION
It seems that on Android 16, registering `ACTION_BOND_STATE_CHANGED` can fail when receiver is not exported. So I have added that.

Additionally, I have just flat out removed the option of exported being null, since this option seems to be broken on newer Android versions.