### PR TITLE
Notifications: Use ARGB instead of RGB, oops

### DIFF
--- a/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/notification/processor/NotificationColors.kt
+++ b/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/notification/processor/NotificationColors.kt
@@ -35,7 +35,7 @@ object HardcodedNotificationColors {
         "com.google.android.apps.photos" to 0xFF0055FF.toInt(),
         "com.linkedin.android" to 0xFF0055AA.toInt(),
         "com.slack" to 0xFFFF0055.toInt(),
-        "com.beeper.android" to 0xAA00FF.toInt(),
-        "com.discord" to 0x5500AA.toInt()
+        "com.beeper.android" to 0xFFAA00FF.toInt(),
+        "com.discord" to 0xFF5500AA.toInt()
     )
 }


### PR DESCRIPTION
In #27, I added hard-coded notification colors for Discord and Beeper on android. Turns out I specified these as RGB when they should have been ARGB, and we got user reports of those notifications showing up pure white on-device - oops!