### PR TITLE
Add icon mapping for "Telegram (Web)" and "Telegram X" apps

### DIFF
--- a/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/notification/processor/BasicNotificationProcessor.kt
+++ b/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/notification/processor/BasicNotificationProcessor.kt
@@ -176,7 +176,7 @@ fun StatusBarNotification.icon(): TimelineIcon = when (packageName) {
     "com.Slack" -> TimelineIcon.NotificationSlack
     "com.snapchat.android" -> TimelineIcon.NotificationSnapchat
     "com.twitter.android", "com.twitter.android.lite" -> TimelineIcon.NotificationTwitter
-    "org.telegram.messenger" -> TimelineIcon.NotificationTelegram
+    "org.telegram.messenger", "org.telegram.messenger.web", "org.thunderdog.challegram" -> TimelineIcon.NotificationTelegram
     "com.facebook.katana", "com.facebook.lite" -> TimelineIcon.NotificationFacebook
     "com.facebook.orca" -> TimelineIcon.NotificationFacebookMessenger
     "com.whatsapp" -> TimelineIcon.NotificationWhatsapp


### PR DESCRIPTION
This merge request contains mappings for official Telegram app (`org.telegram.messenger.web`) from [their website](https://telegram.org/android) and for Telegram X app (`org.thunderdog.challegram`; community-based app officially supported by Telegram itself) from [Google Play](https://play.google.com/store/apps/details?id=org.thunderdog.challegram)