### PR TITLE
Fix CancellationException order

### DIFF
--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/connection/endpointmanager/FirmwareUpdater.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/connection/endpointmanager/FirmwareUpdater.kt
@@ -345,11 +345,13 @@ class RealFirmwareUpdater(
         } catch (e: FirmwareUpdateException) {
             logger.e(e) { "Firmware update failed: ${e.message}" }
            _firmwareUpdateState.value = FirmwareUpdateStatus.NotInProgress.Idle(e)
+        } catch (e: CancellationException) {
+           _firmwareUpdateState.value =
+              FirmwareUpdateStatus.NotInProgress.ErrorStarting(FirmwareUpdateErrorStarting.ErrorDownloading)
+           throw e
         } catch (e: IllegalStateException) {
             logger.e(e) { "Firmware update failed: ${e.message}" }
            _firmwareUpdateState.value = FirmwareUpdateStatus.NotInProgress.Idle(e)
-        } catch (e: CancellationException) {
-            throw e
         } catch (e: Exception) {
             logger.e(e) { "Firmware update failed (unknown): ${e.message}" }
            _firmwareUpdateState.value = FirmwareUpdateStatus.NotInProgress.Idle(e)


### PR DESCRIPTION
It turns out that, on JVM, `CancellationException` extends `IllegalStateException`. Which means that in this big catch in the `FirmwareUpdater`, its catch will never be triggered, because `IllegalStateException` catch will get triggered first.

This PR moves the cancellation catch above `IllegalStateException` and it also updates firmware update state just in case.