### PR TITLE
Add notification icons and colors for EU neobank apps

### DIFF
--- a/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/notification/processor/BasicNotificationProcessor.kt
+++ b/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/notification/processor/BasicNotificationProcessor.kt
@@ -199,6 +199,10 @@ fun StatusBarNotification.icon(): TimelineIcon = when (packageName) {
     "ch.protonmail.android" -> TimelineIcon.GenericEmail
     "me.proton.android.calendar" -> TimelineIcon.TimelineCalendar
     "com.google.android.apps.walletnfcrel" -> TimelineIcon.PayBill
+    "com.revolut.revolut" -> TimelineIcon.PayBill
+    "com.transferwise.android" -> TimelineIcon.PayBill
+    "de.number26.android" -> TimelineIcon.PayBill
+    "com.bunq.android" -> TimelineIcon.PayBill
     "com.google.android.youtube" -> TimelineIcon.TvShow // Use until the YouTube icon is in the fw repo
     "app.revanced.android.youtube" -> TimelineIcon.TvShow // Use until the YouTube icon is in the fw repo
 

--- a/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/notification/processor/NotificationColors.kt
+++ b/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/notification/processor/NotificationColors.kt
@@ -36,6 +36,10 @@ object HardcodedNotificationColors {
         "com.linkedin.android" to 0xFF0055AA.toInt(),
         "com.slack" to 0xFFFF0055.toInt(),
         "com.beeper.android" to 0xFFAA00FF.toInt(),
-        "com.discord" to 0xFF5500AA.toInt()
+        "com.discord" to 0xFF5500AA.toInt(),
+        "com.revolut.revolut" to 0xFF555555.toInt(),
+        "com.transferwise.android" to 0xFF00FF00.toInt(),
+        "de.number26.android" to 0xFF55AAAA.toInt(),
+        "com.bunq.android" to 0xFF00AAFF.toInt()
     )
 }


### PR DESCRIPTION
Add PayBill icon and brand colors for Revolut, Wise, N26, and bunq. 

iOS counterpart: https://github.com/coredevices/PebbleOS/pull/508