### PR TITLE
Always create iOS sources

### DIFF
--- a/libpebble3/build.gradle.kts
+++ b/libpebble3/build.gradle.kts
@@ -50,7 +50,7 @@ android {
 
     buildTypes {
         release {
-            consumerProguardFiles( "consumer-rules.pro")
+            consumerProguardFiles("consumer-rules.pro")
         }
     }
 }
@@ -83,51 +83,51 @@ kotlin {
 
     jvm()
 
-       val xcodeExists by lazy { // Define xcodeExists and xcodeDir here to be accessible by iOS targets
-           project.providers.exec {
-               isIgnoreExitValue = true
-               commandLine("which", "xcode-select")
-           }.result.get().exitValue == 0
-       }
-       val xcodeDir by lazy {
-           if (xcodeExists) {
-               project.providers.exec {
-                   commandLine("xcode-select", "-p")
-               }.standardOutput.asText.get().trim()
-           } else {
-               ""
-           }
-       }
+    val xcodeExists by lazy { // Define xcodeExists and xcodeDir here to be accessible by iOS targets
+        project.providers.exec {
+            isIgnoreExitValue = true
+            commandLine("which", "xcode-select")
+        }.result.get().exitValue == 0
+    }
+    val xcodeDir by lazy {
+        if (xcodeExists) {
+            project.providers.exec {
+                commandLine("xcode-select", "-p")
+            }.standardOutput.asText.get().trim()
+        } else {
+            ""
+        }
+    }
 
-       listOf(
-           iosX64(),
-           iosArm64(),
-           iosSimulatorArm64()
-       ).forEach { target ->
-           if (enableIosTarget) {
-           val osName = when (target.name) {
-               "iosX64" -> "iphonesimulator"
-               "iosArm64" -> "iphoneos"
-               "iosSimulatorArm64" -> "iphonesimulator"
-               else -> throw IllegalStateException("Unknown target: ${target.name}")
-           }
-           val dir = tasks.getByName("buildFrameworkLibPebbleSwift").outputs.files.singleFile.resolve(osName)
-           target.binaries.framework {
-               baseName = "libpebble3"
-           }
-           target.compilations.getByName("main") {
-               val libPebbleSwift by cinterops.creating {
-                   compilerOpts("-framework", "LibPebbleSwift", "-F" + dir.absolutePath)
-               }
-           }
-           target.binaries.all {
-               linkerOpts("-framework", "LibPebbleSwift", "-F" + dir.absolutePath)
-               if (xcodeExists) {
-                   linkerOpts("-L$xcodeDir/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$osName")
-               }
-           }
-       }
-   }
+    listOf(
+        iosX64(),
+        iosArm64(),
+        iosSimulatorArm64()
+    ).forEach { target ->
+        if (enableIosTarget) {
+            val osName = when (target.name) {
+                "iosX64" -> "iphonesimulator"
+                "iosArm64" -> "iphoneos"
+                "iosSimulatorArm64" -> "iphonesimulator"
+                else -> throw IllegalStateException("Unknown target: ${target.name}")
+            }
+            val dir = tasks.getByName("buildFrameworkLibPebbleSwift").outputs.files.singleFile.resolve(osName)
+            target.binaries.framework {
+                baseName = "libpebble3"
+            }
+            target.compilations.getByName("main") {
+                val libPebbleSwift by cinterops.creating {
+                    compilerOpts("-framework", "LibPebbleSwift", "-F" + dir.absolutePath)
+                }
+            }
+            target.binaries.all {
+                linkerOpts("-framework", "LibPebbleSwift", "-F" + dir.absolutePath)
+                if (xcodeExists) {
+                    linkerOpts("-L$xcodeDir/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$osName")
+                }
+            }
+        }
+    }
 
     sourceSets {
         all {
@@ -334,7 +334,7 @@ if (Os.isFamily(Os.FAMILY_MAC)) {
     }
 }*/
 
-abstract class BuildSwiftFramework: DefaultTask() {
+abstract class BuildSwiftFramework : DefaultTask() {
     @Inject
     abstract fun getExecOperations(): ExecOperations
 
@@ -347,7 +347,8 @@ abstract class BuildSwiftFramework: DefaultTask() {
     })
 
     @get:OutputDirectory
-    val outputDir = project.objects.directoryProperty().convention(project.layout.buildDirectory.dir("libpebble-swift/"))
+    val outputDir =
+        project.objects.directoryProperty().convention(project.layout.buildDirectory.dir("libpebble-swift/"))
 
     @TaskAction
     fun buildSwiftFramework() {
@@ -382,7 +383,7 @@ abstract class BuildSwiftFramework: DefaultTask() {
     }
 }
 
-abstract class PlatformFatFramework: DefaultTask() {
+abstract class PlatformFatFramework : DefaultTask() {
     @get:Input
     abstract val platform: Property<String>
 
@@ -393,16 +394,19 @@ abstract class PlatformFatFramework: DefaultTask() {
     val inputFrameworkDSYMs = project.objects.fileCollection()
 
     @Internal
-    val platformOutputDir: Provider<Directory> = platform.map { project.layout.buildDirectory.dir("platform-fat-framework/${it}").get() }
+    val platformOutputDir: Provider<Directory> =
+        platform.map { project.layout.buildDirectory.dir("platform-fat-framework/${it}").get() }
 
     @get:OutputDirectory
     val outputDir = project.objects.directoryProperty().convention(platformOutputDir)
 
     @get:OutputDirectories
-    val outputFiles: Provider<Array<File>> = platformOutputDir.map {arrayOf(
-        it.asFile.toPath().resolve(inputFrameworks.files.first().name).toFile(),
-        it.asFile.toPath().resolve(inputFrameworkDSYMs.files.first().name).toFile()
-    )}
+    val outputFiles: Provider<Array<File>> = platformOutputDir.map {
+        arrayOf(
+            it.asFile.toPath().resolve(inputFrameworks.files.first().name).toFile(),
+            it.asFile.toPath().resolve(inputFrameworkDSYMs.files.first().name).toFile()
+        )
+    }
 
     private fun copyFramework() {
         val file = inputFrameworks.files.first()
@@ -426,9 +430,9 @@ abstract class PlatformFatFramework: DefaultTask() {
             inputs.add(it.toPath().resolve("libpebble3").toString())
         }
         val out = outputDir.get().asFile.toPath()
-            .resolve(inputFrameworks.files.first().name+"/libpebble3").toString()
+            .resolve(inputFrameworks.files.first().name + "/libpebble3").toString()
         project.exec {
-            commandLine ("lipo", "-create", *inputs.toTypedArray(), "-output", out)
+            commandLine("lipo", "-create", *inputs.toTypedArray(), "-output", out)
         }
     }
 
@@ -438,9 +442,9 @@ abstract class PlatformFatFramework: DefaultTask() {
             inputs.add(it.toPath().resolve("Contents/Resources/DWARF/libpebble3").toString())
         }
         val out = outputDir.get().asFile.toPath()
-            .resolve(inputFrameworkDSYMs.files.first().name+"/Contents/Resources/DWARF/libpebble3").toString()
+            .resolve(inputFrameworkDSYMs.files.first().name + "/Contents/Resources/DWARF/libpebble3").toString()
         project.exec {
-            commandLine ("lipo", "-create", *inputs.toTypedArray(), "-output", out)
+            commandLine("lipo", "-create", *inputs.toTypedArray(), "-output", out)
         }
     }
 


### PR DESCRIPTION
this fixes an issue where non-mac machines kept removing the .IO imports. 

It appears that we have to create  iOS targets, we just don't have to do any initialization on the non-mac machines.