### PR TITLE
Show correct order debug options toggle

### DIFF
--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchSettingsScreen.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchSettingsScreen.kt
@@ -1010,16 +1010,6 @@ please disable the option.""".trimIndent(),
                     show = { debugOptionsEnabled },
                 ),
                 basicSettingsToggleItem(
-                    title = "Show debug options",
-                    description = "Show some extra debug options around the app - not useful for most users",
-                    section = Section.Debug,
-                    checked = debugOptionsEnabled,
-                    onCheckChanged = {
-                        settings.set(SHOW_DEBUG_OPTIONS, it)
-                        debugOptionsEnabled = it
-                    },
-                ),
-                basicSettingsToggleItem(
                     title = "Disable FW update notifications",
                     description = "Ignore notifications for users who sideload their own firmware",
                     section = Section.Debug,


### PR DESCRIPTION
The toggle "Show debug options" when activated its in the wrong location, it should always be first in the Debug section.
Unless there is a reason that I can't think of what it would be.

Another thing I notice that when active toggle the UI scrolls up and shows a section called "Watch" with only one option "Ignore Missing PRF" not sure if maybe better to have that option inside the Debug section.

Before:
<img src="https://github.com/user-attachments/assets/699c776a-d97f-4323-9954-ce180cbcf49b" width="300" />
After:
<img src="https://github.com/user-attachments/assets/e3c183a3-133a-43b7-a548-578d3df77f64" width="300" />
