### PR TITLE
Improve the documentation of iOS build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,17 +26,107 @@ Note that by doing so, your app will not be able to be installed alongside other
 
 The cross-platform Pebble mobile app is located in `composeApp`.
 
-Compile on Android with `./gradlew :composeApp:assembleRelease`.
-Compile on iOS in xcode (after running a gradle sync to generate project files).
-
 You will need a GitHub username (`github.username`) and token (`github.token`) configured in `local.properties` to fetch the speex module.
-You will need a `google-services.json` in `composeApp/src` to compile on Android (an examples with dummy values is provided in `google-services-dummy.json`).
-You will need a `GoogleService-Info.plist` in `iosApp/iosApp` to compile on iOS.
-You will need a keystore with some keys if you intend to do a release build on Android (unless you use `LOCAL_RELEASE_BUILD=true` in `gradle.properties`).
 
 Several features (e.g. bug reporting, google login, memfault, online transcription, github developer connection) will not work without tokens configured in `gradle.properties` (but all core features do work).
 
-### Naming your project
+### Android
+* Compile on Android with `./gradlew :composeApp:assembleRelease`.
+* You will need a `google-services.json` in `composeApp/src` to compile on Android (an examples with dummy values is provided in `google-services-dummy.json`).
+* You will need a keystore with some keys if you intend to do a release build on Android (unless you use `LOCAL_RELEASE_BUILD=true` in `gradle.properties`).
+
+### iOS
+
+#### Prerequisites
+
+1. **Install Java 17**
+
+   ```bash
+   # Install
+   brew install openjdk@17
+   
+   # Symlink (optional)
+   sudo ln -sfn /opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk-17.jdk
+   
+   # Verify installation
+   /usr/libexec/java_home -v 17
+   ```
+
+2. **Install CocoaPods**
+
+   ```bash
+   # Install
+   brew install cocoapods
+   
+   # Symlink (optional)
+   sudo ln -s /opt/homebrew/bin/pod /usr/local/bin/pod
+   ```
+
+3. **Setup GitHub token for speex module**
+
+    Create a `local.properties` file in the project root with your GitHub credentials.
+
+#### Configuration
+
+4. **Configure Entitlements**
+
+   Set `iosApp/iosApp/iosApp.entitlements` to an empty dictionary:
+
+   ```xml
+   <?xml version="1.0" encoding="UTF-8"?>
+   <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+   <plist version="1.0">
+   <dict>
+   </dict>
+   </plist>
+   ```
+
+5. **Install CocoaPods dependencies**
+
+   ```bash
+   ./gradlew podInstall
+   ```
+
+   This will create `Podfile.lock` and set up all required dependencies.
+
+6. **Configure Bundle ID and Signing**
+
+   - Open `iosApp/iosApp.xcworkspace` in Xcode (⚠️ **Important**: use `.xcworkspace`, not `.xcodeproj`)
+   - Go to the target `iosApp` → **Signing & Capabilities**
+   - Set your **Team** (your Apple Developer account)
+   - Set **Bundle Identifier** to your own (e.g., `com.yourname.coredevices.coreapp`)
+
+7. **Configure Firebase**
+
+   - Create a free Firebase account at https://console.firebase.google.com
+   - Create a new iOS app with the same Bundle ID you set above
+   - Download `GoogleService-Info.plist` and place it in `iosApp/iosApp/`
+   - The file should be named exactly `GoogleService-Info.plist`
+
+8. **Create a git tag for app version**
+
+   Create a git tag that will be used as the version of the app:
+
+   ```bash
+   git tag 1.0.0
+   ```
+
+#### Build and Run
+
+9. **Build and run in Xcode**
+
+   - Open `iosApp/iosApp.xcworkspace` in Xcode
+   - Select your target device or simulator and run.
+
+   > **Tip**: If you encounter module not found errors (`Mixpanel`, `FirebaseCore`, etc.), make sure you:
+   > - Opened the `.xcworkspace` file (not `.xcodeproj`)
+   > - Ran `pod install` successfully
+   > - Cleaned the build folder (`Product → Clean Build Folder`)
+
+
+
+
+# Naming your project
 
 In order to honour the Pebble trademark, you may not use "Pebble" in the name of your app, product or service, except in a referential manner. For example, "Awesome App for Pebble" is acceptable, but "Pebble Awesome" is not.
 


### PR DESCRIPTION
Improve the documentation for iOS build instructions.
I don't know much about iOS development, so there might be some obvious things I added that aren't really necessary. 
But after a lot of trial and error, I was able to summarize it down to the most basic information needed for compilation.