### PR TITLE
Parse per-notification vibration patterns from the notification body

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,11 +1,11 @@
 #Kotlin
 kotlin.code.style=official
-kotlin.daemon.jvmargs=-Xmx6G
+kotlin.daemon.jvmargs=-Xmx2G
 ksp.useKSP2=true
 kotlin.apple.deprecated.allowUsingEmbedAndSignWithCocoaPodsDependencies=true
 
 #Gradle
-org.gradle.jvmargs=-Xmx8g -XX:+UseSerialGC
+org.gradle.jvmargs=-Xmx2g -XX:+UseSerialGC
 org.gradle.parallel=true
 org.gradle.caching=true
 


### PR DESCRIPTION
It turns out Android can't actually set per-notification vibration patterns since Android 8. So the code that's currently in the app that tries to grab the vibration pattern from the notification just always returns null. The only way to set custom vibration patterns in modern Android is by setting the notification channel's vibration pattern. And other apps aren't allowed to read this pattern. This is a (perhaps a little hacky) workaround for that. If a notification body contains a `|` symbol followed by a comma-separated list of numbers, it'll parse that as a vibration pattern instead and remove it from the body when displaying on the watch. If it can't parse it, then it will leave the body and vibration pattern untouched.