### PR TITLE
Add option to always send paused state

### DIFF
--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/LibPebbleConfig.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/LibPebbleConfig.kt
@@ -67,6 +67,12 @@ data class WatchConfig(
     val preferBtClassicV2: Boolean = false,
     val pkjsInspectable: Boolean = false,
     val emulateRemoteTimeline: Boolean = true,
+    /**
+     * When true, LibPebble3 will always send music state as paused, never as playing.
+     *
+     * This prevents music app from jumping to the top of the list.
+     */
+    val alwaysSendMusicPaused: Boolean = false,
 )
 
 class WatchConfigFlow(val flow: StateFlow<LibPebbleConfig>) {


### PR DESCRIPTION
Added a small option to the config that always sends the music state as paused. This prevents Music app from jumping to the top of the menu.

Useful if user is using a 3rd-party music app, so the native controls don't get in the way.