### PR TITLE
Fix timeout issue sideload FW on iOS

### DIFF
--- a/libpebble3/src/iosMain/kotlin/io/rebble/libpebblecommon/di/LibPebbleModule.ios.kt
+++ b/libpebble3/src/iosMain/kotlin/io/rebble/libpebblecommon/di/LibPebbleModule.ios.kt
@@ -74,5 +74,7 @@ actual val platformModule: Module = module {
         fallbackToResetRequest = true,
         closeGattServerWhenBtDisabled = false,
         delayBleConnectionsAfterAppStart = true,
+        desiredTxWindow = 6,
+        desiredRxWindow = 6,
     ) }
 }


### PR DESCRIPTION
There's a problem on iOS with uploading custom FW, it almost always fails due to a timeout or because very large data packets are sent in a short period, causing the BL connection to fail.

Lowering the desiredRxWindow value from the default 25 to 6 has improved things. It worked well for me about 95% of the time without any issues.

However, this change affects not only sideloading but all communication between the Pebble and iPhone.
I notice that watchfaces/apps upload a little slower than usual with 25, notifications works as normal as before.

Perhaps we should look into a way to isolate the use of desiredRxWindow=6 for sideloading only, but that would require significant changes.
Old pebble supposedly use desiredRxWindow with 4.

I'm not sure if the same thing is happening on Android, or if it works fine and the problem is on iOS where large packets in a short period cause the BL connection to collapse.