### PR TITLE
Fix iOS bundle JS Initialization 

### DIFF
--- a/libpebble3/src/iosMain/kotlin/io/rebble/libpebblecommon/js/JavascriptCoreJsRunner.kt
+++ b/libpebble3/src/iosMain/kotlin/io/rebble/libpebblecommon/js/JavascriptCoreJsRunner.kt
@@ -46,7 +46,6 @@ class JavascriptCoreJsRunner(
     urlOpenRequests: Channel<String>,
     private val logMessages: Channel<String>,
     private val remoteTimelineEmulator: RemoteTimelineEmulator,
-    private val pkjsBundleIdentifier: String? = "coredevices.coreapp",
 ): JsRunner(appInfo, lockerEntry, jsPath, device, urlOpenRequests) {
     private var jsContext: JSContext? = null
     private val logger = Logger.withTag("JSCRunner-${appInfo.longName}")
@@ -102,9 +101,7 @@ class JavascriptCoreJsRunner(
     }
 
     private fun evaluateInternalScript(filenameNoExt: String) {
-        val bundle = pkjsBundleIdentifier
-            ?.let { NSBundle.bundleWithIdentifier(it) ?: error("PKJS bundle with identifier $it not found") }
-            ?: NSBundle.mainBundle
+        val bundle = NSBundle.mainBundle
         val path = bundle.pathForResource(filenameNoExt, "js")
             ?: error("Startup script not found in bundle")
         val js = SystemFileSystem.source(Path(path)).buffered().use {


### PR DESCRIPTION
If we compile and deploy this manually, it fails the JS.
We cannot enter Settings of each app/watchface,because the bundleID for iOS must be different from the core bundleID.

```
CompanionAppLifecycleManager) Failed to init Companion app for app 240d60a3-7952-4094-a456-c187c46c2f52: PKJS bundle with identifier coredevices.coreapp not found
kotlin.IllegalStateException: PKJS bundle with identifier coredevices.coreapp not found
    at 0   ComposeApp                          0x10d5b616b        kfun:kotlin.Throwable#<init>(kotlin.String?){} + 99 
    at 1   ComposeApp                          0x10d5afe93        kfun:kotlin.Exception#<init>(kotlin.String?){} + 95 
    at 2   ComposeApp                          0x10d5b0063        kfun:kotlin.RuntimeException#<init>(kotlin.String?){} + 95 
    at 3   ComposeApp                          0x10d5b0527        kfun:kotlin.IllegalStateException#<init>(kotlin.String?){} + 95 
    at 4   ComposeApp                          0x10e12f25f        kfun:io.rebble.libpebblecommon.js.JavascriptCoreJsRunner.io.rebble.libpebblecommon.js.JavascriptCoreJsRunner#evaluateInternalScript(kotlin.String){} + 1275 
    at 5   ComposeApp                          0x10e130593        kfun:io.rebble.libpebblecommon.js.JavascriptCoreJsRunner.io.rebble.libpebblecommon.js.JavascriptCoreJsRunner#evaluateStandardLib(){} + 75 
    at 6   ComposeApp                          0x10e130c1f        kfun:io.rebble.libpebblecommon.js.JavascriptCoreJsRunner#start#suspend(kotlin.coroutines.Continuation<kotlin.Unit>){}kotlin.Any + 1139 
    at 7   ComposeApp                          0x10e083af7        kfun:io.rebble.libpebblecommon.js.JsRunner#start#suspend(kotlin.coroutines.Continuation<kotlin.Unit>){}kotlin.Any-trampoline + 67 
    at 8   ComposeApp                          0x10e07a107        kfun:io.rebble.libpebblecommon.js.PKJSApp#start#suspend(kotlinx.coroutines.CoroutineScope;kotlin.coroutines.Continuation<kotlin.Unit>){}kotlin.Any + 1083 
    at 9   ComposeApp                          0x10e08222f        kfun:io.rebble.libpebblecommon.connection.CompanionApp#start#suspend(kotlinx.coroutines.CoroutineScope;kotlin.coroutines.Continuation<kotlin.Unit>){}kotlin.Any-tra
```