### PR TITLE
Fix accessing variable from wrong dict in pkjs startup

### DIFF
--- a/libpebble3/src/androidMain/assets/startup.js
+++ b/libpebble3/src/androidMain/assets/startup.js
@@ -306,7 +306,7 @@ navigator.geolocation.clearWatch = (id) => {
             if (onSuccess) {
                 const callback = (e) => {
                     try {
-                        if (e.payload.data.transactionId === transactionId) {
+                        if (e.payload.transactionId === transactionId) {
                             onSuccess(e.payload);
                         }
                     } catch (error) {
@@ -319,7 +319,7 @@ navigator.geolocation.clearWatch = (id) => {
             if (onFailure) {
                 const callback = (e) => {
                     try {
-                        if (e.payload.data.transactionId === transactionId) {
+                        if (e.payload.transactionId === transactionId) {
                             onFailure(e.payload, e.payload.error);
                         }
                     } catch (error) {


### PR DESCRIPTION
Hexxeh on discord brought up this issue:

```
[20:36:23] pkjs> Bobby:? PKJS Error in app message failure callback 
{
  "message": "Cannot read properties of undefined (reading 'transactionId')",
  "name": "TypeError",
  "stack": "TypeError: Cannot read properties of undefined (reading 'transactionId')\n    at callback (file:///android_asset/startup.js:322:44)\n    at file:///android_asset/startup.js:190:44\n    at Array.forEach (<anonymous>)\n    at PebbleEventListener.dispatchEvent (file:///android_asset/startup.js:188:27)\n    at dispatchPebbleEvent (file:///android_asset/startup.js:213:35)\n    at global.signalAppMessageNack (file:///android_asset/startup.js:257:9)\n    at <anonymous>:1:1"
}
```

Because `.transactionId` isn't inside `data` rather the parent `payload`. See ln 251: https://github.com/KonradIT/libpebble3/blob/913b45c287fbb7801a384697eaaaac52eb745a69/libpebble3/src/androidMain/assets/startup.js#L251

