### PR TITLE
calls: fix call duration timer started for STATE_DISCONNECTING

### DIFF
--- a/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/calls/LibPebbleInCallService.kt
+++ b/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/calls/LibPebbleInCallService.kt
@@ -121,7 +121,7 @@ class LibPebbleInCallService : InCallService(), LibPebbleKoinComponent {
                 onCallEnd = { call.disconnect() },
                 cookie = cookie,
             )
-            Call.STATE_ACTIVE, Call.STATE_DISCONNECTING -> io.rebble.libpebblecommon.calls.Call.ActiveCall(
+            Call.STATE_ACTIVE -> io.rebble.libpebblecommon.calls.Call.ActiveCall(
                 contactName = call.resolveContactName(),
                 contactNumber = call.resolveContactNumber(),
                 onCallEnd = { call.disconnect() },


### PR DESCRIPTION
This PR fixes [coredevices/PebbleOS#808](https://github.com/coredevices/PebbleOS/issues/808) — abnormal call durations and incorrect status text for unanswered calls on Pebble smartwatches.

When an incoming call is not answered on a Pebble watch, the watch sometimes displays an abnormal call duration (e.g., `491791:41:09`). The root cause is in LibPebbleInCallService.kt, which maps both Call.STATE_ACTIVE and Call.STATE_DISCONNECTING to ActiveCall. When a call disconnects before being answered, the old timestamp persists and gets used to compute a garbage duration across the entire idle period.

Changes:
Remove Call.STATE_DISCONNECTING from the ActiveCall mapping — only truly active calls now trigger the duration timer. Calls that disconnect before being answered skip the timer entirely.