### PR TITLE
Fix DictationResult serialization when sending UTF-8 text

### DIFF
--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/packets/Voice.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/packets/Voice.kt
@@ -30,9 +30,10 @@ enum class VoiceCommand(val value: UByte) {
 }
 
 class Word(confidence: UByte = 0u, data: String = "") : StructMappable() {
+    private val utf8Size = data.encodeToByteArray().size.coerceAtMost(UShort.MAX_VALUE.toInt())
     val confidence = SUByte(m, confidence)
-    val length = SUShort(m, data.length.toUShort(), endianness = Endian.Little)
-    val data = SFixedString(m, data.length, data)
+    val length = SUShort(m, utf8Size.toUShort(), endianness = Endian.Little)
+    val data = SFixedString(m, utf8Size, data)
     init {
         this.data.linkWithSize(length)
     }


### PR DESCRIPTION
I speak languages that use the Cyrillic script, and whenever I used speech recognition, the output was always garbled: half of each word was cut off.

I finally found why: it’s the serialization between the app and the watch. We used string length in characters where we should use UTF-8 length in bytes — a classic mistake. English speakers wouldn’t really hit this bug; for non‑Latin languages it’s a serious issue.