### PR TITLE
Add Notifications Mute status

### DIFF
--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/NotificationAppScreen.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/NotificationAppScreen.kt
@@ -10,6 +10,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.Spacer
+import kotlin.time.Clock
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
@@ -189,7 +191,7 @@ fun NotificationAppScreen(
                             }
                         }
                     }
-                    LazyColumn {
+                    LazyColumn(modifier = Modifier.weight(1f)) {
                         items(
                             items = channelGroups,
                             key = { it.id },
@@ -219,6 +221,46 @@ fun NotificationAppScreen(
                         }
                     }
                 }
+
+                if (platform == Platform.IOS) {
+                    Spacer(modifier = Modifier.weight(1f))
+                }
+
+                val expiration = app.muteExpiration
+                val now = Clock.System.now()
+                val isTemporaryMuted = expiration != null && expiration.isAfter(now)
+
+                val muteReasonText = when {
+                    isTemporaryMuted -> {
+                        val duration = expiration!!.instant - now
+                        val timeString = duration.toComponents { hours, minutes, _, _ ->
+                            if (hours > 0) {
+                                "${hours}h ${minutes}m"
+                            } else {
+                                "${minutes}m"
+                            }
+                        }
+                        if (duration.inWholeHours >= 2) {
+                            "Status: Muted for the day ($timeString left)"
+                        } else {
+                            "Status: Muted for 1 hour ($timeString left)"
+                        }
+                    }
+                    app.muteState == MuteState.Always -> "Status: Muted (Always)"
+                    app.muteState == MuteState.Weekdays -> "Status: Muted (Weekdays)"
+                    app.muteState == MuteState.Weekends -> "Status: Muted (Weekends)"
+                    else -> null
+                }
+
+                if (muteReasonText != null) {
+                    Text(
+                        text = muteReasonText,
+                        color = MaterialTheme.colorScheme.error,
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp).fillMaxWidth(),
+                        textAlign = androidx.compose.ui.text.style.TextAlign.Center,
+                        style = MaterialTheme.typography.bodyLarge
+                    )
+                }
             }
         }
     }
@@ -233,18 +275,11 @@ private fun ChannelCard(
     nav: NavBarNav,
 ) {
     val expiration = app.muteExpiration
+    val now = Clock.System.now()
     val appMuted = when {
-        // Check temporary mute first (takes priority)
-        expiration != null -> {
-            // Temporary mute: check if it hasn't expired yet
-            val now = kotlin.time.Clock.System.now()
-            expiration.isAfter(now)
-        }
+        expiration != null && expiration.isAfter(now) -> true
         app.muteState == MuteState.Never -> false
-        else -> {
-            // Permanent or schedule-based mute (Always, Weekdays, Weekends)
-            true
-        }
+        else -> true
     }
     val channelMuted = channelItem.muteState != MuteState.Never
     val count = channelCounts[channelItem.id]?.count

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/NotificationAppsScreen.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/NotificationAppsScreen.kt
@@ -48,6 +48,8 @@ import coredevices.ui.PebbleElevatedButton
 import io.rebble.libpebblecommon.connection.NotificationApps
 import io.rebble.libpebblecommon.database.entity.MuteState
 import io.rebble.libpebblecommon.database.entity.everNotified
+import io.rebble.libpebblecommon.database.isAfter
+import kotlin.time.Clock
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
@@ -101,10 +103,27 @@ fun NotificationAppsScreen(topBarParams: TopBarParams, nav: NavBarNav, gotoDefau
                         app.app.everNotified() || !viewModel.onlyNotified.value
                     }
                 }
+                val now = Clock.System.now()
                 val filteredByEnabled = when (viewModel.enabledFilter.value) {
                     EnabledFilter.All -> filtered
-                    EnabledFilter.EnabledOnly -> filtered.filter { it.app.muteState == MuteState.Never }
-                    EnabledFilter.DisabledOnly -> filtered.filter { it.app.muteState != MuteState.Never }
+                    EnabledFilter.EnabledOnly -> filtered.filter {
+                        val expr = it.app.muteExpiration
+                        val isMuted = when {
+                            expr != null && expr.isAfter(now) -> true
+                            it.app.muteState == MuteState.Never -> false
+                            else -> true
+                        }
+                        !isMuted
+                    }
+                    EnabledFilter.DisabledOnly -> filtered.filter {
+                        val expr = it.app.muteExpiration
+                        val isMuted = when {
+                            expr != null && expr.isAfter(now) -> true
+                            it.app.muteState == MuteState.Never -> false
+                            else -> true
+                        }
+                        isMuted
+                    }
                 }
 
                 val list = when (viewModel.sortBy.value) {

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/NotificationsScreen.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/NotificationsScreen.kt
@@ -154,16 +154,14 @@ fun NotificationAppCard(
     } else Modifier
     val muted = remember(app) {
         val expiration = app.muteExpiration
+        val now = Clock.System.now()
         when {
             // Check temporary mute first (takes priority)
-            expiration != null -> {
-                // Temporary mute: check if it hasn't expired yet
-                val now = Clock.System.now()
-                expiration.isAfter(now)
-            }
+            expiration != null && expiration.isAfter(now) -> true
             app.muteState == MuteState.Never -> false
             else -> {
                 // Permanent or schedule-based mute (Always, Weekdays, Weekends)
+                // If temporary mute is present but expired, it correctly falls back here.
                 true
             }
         }


### PR DESCRIPTION
* A bug was fixed where the mute toggle was not reflecting the correct status when the muteExpiration setting had an expired date and was subsequently reactivated.

* A status was added to the notification app view that indicates whether the mute is always active, active on weekends/weekdays, or only active on specific hours/days.

<img width="200" height="400" alt="IMG_1999" src="https://github.com/user-attachments/assets/bccf05cf-9c86-4209-ae33-3ff0bce7a6d9" />
<img width="200" height="400" alt="IMG_1992" src="https://github.com/user-attachments/assets/e9863ffe-c209-496a-8a26-4ec6a5e330c9" />
<img width="200" height="400" alt="IMG_1994" src="https://github.com/user-attachments/assets/9b6b1f13-d7a6-468f-842b-f7bc830afbd8" />