### PR TITLE
Fix iOS Sign button

### DIFF
--- a/util/src/iosMain/kotlin/coredevices/ui/SignInButton.ios.kt
+++ b/util/src/iosMain/kotlin/coredevices/ui/SignInButton.ios.kt
@@ -44,5 +44,7 @@ internal actual suspend fun signInWithCredential(credential: AuthCredential) {
                 } ?: throw IllegalStateException("Linking succeeded but no credential returned")
             }
         }
+    } else {
+        Firebase.auth.signInWithCredential(credential)
     }
 }


### PR DESCRIPTION
It what missing a case when the user was not isAnonymous (Android already has it)