### PR TITLE
Move notification channel items within the same object as the title

### DIFF
--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/NotificationAppScreen.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/NotificationAppScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.SegmentedButton
@@ -198,12 +199,11 @@ fun NotificationAppScreen(
                             ) {
                                 Row(
                                     verticalAlignment = Alignment.CenterVertically,
-                                    horizontalArrangement = Arrangement.SpaceEvenly,
-                                    modifier = Modifier.fillMaxWidth(),
+                                    horizontalArrangement = Arrangement.SpaceBetween,
+                                    modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
                                 ) {
-                                    Text("Channels", fontSize = 20.sp, modifier = Modifier.padding(5.dp))
+                                    Text("Channels", fontSize = 20.sp)
                                     FilterChip(
-                                        modifier = Modifier.padding(5.dp),
                                         onClick = {
                                             viewModel.onlyNotified.value = !viewModel.onlyNotified.value
                                         },
@@ -224,35 +224,30 @@ fun NotificationAppScreen(
                                         },
                                     )
                                 }
+                                channelGroups.forEach { group ->
+                                    if (channelGroups.size > 1) {
+                                        Text(
+                                            text = group.name ?: "Default Group",
+                                            style = MaterialTheme.typography.titleSmall,
+                                            color = MaterialTheme.colorScheme.primary,
+                                            modifier = Modifier.padding(horizontal = 16.dp).padding(top = 4.dp).padding(bottom = 4.dp),
+                                        )
+                                    }
+                                    group.channels.forEach { channel ->
+                                        ChannelCard(
+                                            channelItem = channel,
+                                            app = app,
+                                            notificationApps = notificationApps,
+                                            channelCounts = channelCounts,
+                                            nav = nav,
+                                        )
+                                    }
+                                    if (group != channelGroups.last()) {
+                                        HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+                                    }
+                                }
                             }
                         }
-                    }
-                    items(
-                        items = channelGroups,
-                        key = { it.id },
-                    ) { group ->
-                        if (channelGroups.size > 1) {
-                            ListItem(
-                                headlineContent = {
-                                    Text(
-                                        text = group.name ?: "Default Group",
-                                        style = MaterialTheme.typography.titleSmall,
-                                        color = MaterialTheme.colorScheme.primary,
-                                        modifier = Modifier.padding(vertical = 8.dp),
-                                    )
-                                }
-                            )
-                        }
-                        group.channels.forEach { channel ->
-                            ChannelCard(
-                                channelItem = channel,
-                                app = app,
-                                notificationApps = notificationApps,
-                                channelCounts = channelCounts,
-                                nav = nav,
-                            )
-                        }
-                        HorizontalDivider(modifier = Modifier.padding(top = 8.dp))
                     }
                 }
 
@@ -312,7 +307,7 @@ private fun NotificationRulesSection(
         elevation = CardDefaults.cardElevation(defaultElevation = 6.dp),
         modifier = Modifier.padding(10.dp).fillMaxWidth(),
     ) {
-        Column(modifier = Modifier.padding(12.dp)) {
+        Column(modifier = Modifier.padding(16.dp)) {
             Text("Notification filter rules", fontSize = 20.sp, modifier = Modifier.padding(bottom = 8.dp))
             Text(
                 if (rules.isEmpty()) "No notification rules"
@@ -524,6 +519,7 @@ private fun ChannelCard(
     } else Modifier
     ListItem(
         modifier = modifier,
+        colors = ListItemDefaults.colors(containerColor = Color.Transparent),
         headlineContent = {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Text(channelItem.name, fontSize = 17.sp)


### PR DESCRIPTION
As mentioned in #135.

Significantly improves aesthetics, imo. Also tweaked sizing and spacing a bit. Could make the height of the items lower also perhaps, there's a lot of dead space.

<img width="461" height="1024" alt="signal-2026-04-15-185448_002" src="https://github.com/user-attachments/assets/bf626db6-fc92-4bd5-a539-c2bc734e3d81" />
