### PR TITLE
Cohorts improvements

### DIFF
--- a/pebble/src/commonMain/kotlin/coredevices/pebble/firmware/Cohorts.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/firmware/Cohorts.kt
@@ -1,6 +1,8 @@
 package coredevices.pebble.firmware
 
+import CoreAppVersion
 import co.touchlab.kermit.Logger
+import coredevices.pebble.account.bootConfigPlatform
 import coredevices.pebble.services.HttpClientAuthType
 import coredevices.pebble.services.PebbleHttpClient
 import coredevices.pebble.services.PebbleHttpClient.Companion.get
@@ -14,36 +16,41 @@ import kotlin.time.Instant
 
 class Cohorts(
     private val httpClient: PebbleHttpClient,
+    private val appVersion: CoreAppVersion,
 ) {
     private val logger = Logger.withTag("Cohorts")
 
     suspend fun getLatestFirmware(watch: WatchInfo): FirmwareUpdateCheckResult {
         logger.v { "getLatestFirmware" }
-        // GitHub raw returns text/plain, so fetch as String and deserialize manually
-        val responseText: String? = httpClient.get(LOGGED_OUT_URL, auth = HttpClientAuthType.None)
-        if (responseText == null) {
+        val hardware = watch.platform.revision
+        val platform = bootConfigPlatform()
+        val parameters = mapOf(
+            "select" to "fw",
+            "hardware" to hardware,
+            "mobilePlatform" to platform,
+            "mobileVersion" to appVersion.version,
+            "mobileHardware" to platform,
+            "pebbleAppVersion" to appVersion.version,
+        )
+        val response: CohortsResponse? = httpClient.get(
+            "$COHORTS_URL/cohort",
+            auth = HttpClientAuthType.PebbleOptional,
+            parameters = parameters,
+        )
+        if (response == null) {
             logger.i { "No response from cohorts" }
             return FirmwareUpdateCheckResult.UpdateCheckFailed("Failed to check for PebbleOS update")
         }
-        val response = try {
-            json.decodeFromString<CohortsResponse>(responseText)
-        } catch (e: Exception) {
-            logger.e(e) { "Failed to parse cohorts response" }
-            return FirmwareUpdateCheckResult.UpdateCheckFailed("Failed to check for PebbleOS update")
-        }
-//        logger.v { "response: $response" } // TODO remove
-        // (differently from memfault) cohorts always returns the latest (we didn't pass the current
-        // version to it), so we need to check whether it needs an update
-        val normalFw = response.hardware[watch.platform.revision]?.normal
+        val normalFw = response.fw?.normal
         if (normalFw == null) {
-            logger.i { "No firmware found for ${watch.platform.revision}" }
+            logger.i { "No firmware found for $hardware" }
             return FirmwareUpdateCheckResult.UpdateCheckFailed("Failed to check for PebbleOS update")
         }
         val latestFwVersion = FirmwareVersion.from(
-            tag = normalFw.version,
+            tag = normalFw.friendlyVersion.removePrefix("v"),
             isRecovery = false,
             gitHash = "", // TODO
-            timestamp = Instant.DISTANT_PAST, // TODO
+            timestamp = Instant.fromEpochSeconds(normalFw.timestamp),
             isDualSlot = false, // not used from here
             isSlot0 = false, // not used from here
         )
@@ -54,8 +61,8 @@ class Cohorts(
         if (watch.runningFwVersion.isRecovery || latestFwVersion > watch.runningFwVersion) {
             return FirmwareUpdateCheckResult.FoundUpdate(
                 version = latestFwVersion,
-                url = "https://binaries.rebble.io/fw/${watch.platform.revision}/Pebble-${normalFw.version}-${watch.platform.revision}.pbz",
-                notes = response.notes[normalFw.version] ?: "",
+                url = normalFw.url,
+                notes = normalFw.notes.orEmpty(),
             )
         } else {
             return FirmwareUpdateCheckResult.FoundNoUpdate
@@ -63,26 +70,27 @@ class Cohorts(
     }
 
     companion object {
-        private const val LOGGED_OUT_URL = "https://raw.githubusercontent.com/pebble-dev/rebble-cohorts/refs/heads/master/config.json"
-        private val json = Json { ignoreUnknownKeys = true }
+        private const val COHORTS_URL = "https://cohorts.rebble.io"
     }
 }
 
 @Serializable
 data class CohortsResponse(
-    val notes: Map<String, String>,
-    val timestamps: Map<String, Long>,
-    val hardware: Map<String, CohortsFirmwareType>
+    val fw: CohortsFirmwareType? = null,
 )
 
 @Serializable
 data class CohortsFirmwareType(
-    val normal: CohortsFirmware,
+    val normal: CohortsFirmware? = null,
+    val recovery: CohortsFirmware? = null,
 )
 
 @Serializable
 data class CohortsFirmware(
-    val version: String,
+    val url: String,
     @SerialName("sha-256")
     val sha256: String,
+    val friendlyVersion: String,
+    val timestamp: Long,
+    val notes: String? = null,
 )

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/firmware/Cohorts.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/firmware/Cohorts.kt
@@ -11,7 +11,6 @@ import io.rebble.libpebblecommon.services.FirmwareVersion
 import io.rebble.libpebblecommon.services.WatchInfo
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.Json
 import kotlin.time.Instant
 
 class Cohorts(
@@ -47,7 +46,7 @@ class Cohorts(
             return FirmwareUpdateCheckResult.UpdateCheckFailed("Failed to check for PebbleOS update")
         }
         val latestFwVersion = FirmwareVersion.from(
-            tag = normalFw.friendlyVersion.removePrefix("v"),
+            tag = normalFw.friendlyVersion,
             isRecovery = false,
             gitHash = "", // TODO
             timestamp = Instant.fromEpochSeconds(normalFw.timestamp),

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/firmware/FirmwareUpdateCheck.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/firmware/FirmwareUpdateCheck.kt
@@ -1,6 +1,7 @@
 package coredevices.pebble.firmware
 
 import coredevices.pebble.services.Memfault
+import coredevices.util.CommonBuildKonfig
 import io.rebble.libpebblecommon.connection.FirmwareUpdateCheckResult
 import io.rebble.libpebblecommon.metadata.WatchHardwarePlatform
 import io.rebble.libpebblecommon.metadata.WatchHardwarePlatform.*
@@ -12,7 +13,7 @@ class FirmwareUpdateCheck(
 ) {
     suspend fun checkForUpdates(watch: WatchInfo): FirmwareUpdateCheckResult = when {
         watch.platform == UNKNOWN -> FirmwareUpdateCheckResult.UpdateCheckFailed("Unknown platform")
-        watch.platform.isCoreDevice() -> memfault.getLatestFirmware(watch)
+        watch.platform.isCoreDevice() && CommonBuildKonfig.MEMFAULT_TOKEN != null -> memfault.getLatestFirmware(watch)
         else -> cohorts.getLatestFirmware(watch)
     }
 }

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/services/PebbleWebServices.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/services/PebbleWebServices.kt
@@ -98,8 +98,14 @@ private val logger = Logger.withTag("PebbleHttpClient")
 
 enum class HttpClientAuthType {
     Pebble,
+    PebbleOptional,
     Core,
     None,
+}
+
+private fun HttpClientAuthType.requiresToken(): Boolean = when (this) {
+    HttpClientAuthType.Pebble, HttpClientAuthType.Core -> true
+    HttpClientAuthType.PebbleOptional, HttpClientAuthType.None -> false
 }
 
 class PebbleHttpClient(
@@ -111,7 +117,7 @@ class PebbleHttpClient(
     }
     companion object {
         suspend fun PebbleHttpClient.authFor(type: HttpClientAuthType): String? = when (type) {
-            HttpClientAuthType.Pebble -> pebbleAccount.get().loggedIn.value
+            HttpClientAuthType.Pebble, HttpClientAuthType.PebbleOptional -> pebbleAccount.get().loggedIn.value
             HttpClientAuthType.Core -> try {
                 Firebase.auth.currentUser?.getIdToken(false)
             } catch (e: Exception) {
@@ -126,7 +132,7 @@ class PebbleHttpClient(
             auth: HttpClientAuthType,
         ): HttpResponse? {
             val token = authFor(auth)
-            if (auth != HttpClientAuthType.None && token == null) {
+            if (auth.requiresToken() && token == null) {
                 logger.i("not logged in")
                 return null
             }
@@ -149,7 +155,7 @@ class PebbleHttpClient(
             auth: HttpClientAuthType,
         ): HttpResponse? {
             val token = authFor(auth)
-            if (auth != HttpClientAuthType.None && token == null) {
+            if (auth.requiresToken() && token == null) {
                 logger.i("not logged in")
                 return null
             }
@@ -172,7 +178,7 @@ class PebbleHttpClient(
             auth: HttpClientAuthType,
         ): Boolean {
             val token = authFor(auth)
-            if (auth != HttpClientAuthType.None && token == null) {
+            if (auth.requiresToken() && token == null) {
                 logger.i("not logged in")
                 return false
             }
@@ -197,7 +203,7 @@ class PebbleHttpClient(
         ): T? {
             logger.v("get: ${url.sanitizeUrl()} auth=$auth")
             val token = authFor(auth)
-            if (auth != HttpClientAuthType.None && token == null) {
+            if (auth.requiresToken() && token == null) {
                 logger.i("not logged in")
                 return null
             }


### PR DESCRIPTION
Two parts to this PR:
- Always fall back to cohorts for updates if no memfault project key is provided. Relates to the comments within https://github.com/coredevices/mobileapp/issues/55
- Utilize cohorts API properly instead of using the source json in github.

Reasoning:

It's not great that the self-built versions of the app cannot receive updates for the coredevices watches, and the option with least code changes here to get there was to fall back to cohorts in that case. The updates are quite frequent over there from what I see (every few days) and so it'd be a big hassle to update manually, so I believe there's value in implementing this fallback.

I also took the liberty to work with rebble folks to make auth optional there (specifying is still useful for statistics), so you can e.g. [click here](https://cohorts.rebble.io/cohort?select=fw&hardware=silk&mobilePlatform=test&mobileVersion=test&mobileHardware=test&pebbleAppVersion=test) and get update info without authenticating now.

Now I'm working with them to make cohorts also serve the coredevices firmwares, and that's not likely to end up in the config.json with the way we've been brainstorming so far, so that required the second half of these changes.