### PR TITLE
iOS: make single click and hold configurable (Index Agent or Webhook)

### DIFF
--- a/experimental/src/commonMain/kotlin/coredevices/ring/database/Preferences.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/database/Preferences.kt
@@ -25,6 +25,8 @@ interface Preferences {
     val debugDetailsEnabled: StateFlow<Boolean>
     val approvedBeeperContacts: StateFlow<List<ApprovedBeeperContact>>
     val secondaryMode: StateFlow<SecondaryMode>
+    val primaryMode: StateFlow<PrimaryMode>
+    val shareWithIndexAgent: StateFlow<Boolean>
     val reminderProvider: StateFlow<ReminderProvider>
     val noteProvider: StateFlow<NoteProvider>
     val noteShortcut: StateFlow<NoteShortcutType>
@@ -41,6 +43,8 @@ interface Preferences {
     fun setDebugDetailsEnabled(enabled: Boolean)
     suspend fun setApprovedBeeperContacts(contacts: List<ApprovedBeeperContact>?)
     fun setSecondaryMode(mode: SecondaryMode)
+    fun setPrimaryMode(mode: PrimaryMode)
+    fun setShareWithIndexAgent(value: Boolean)
     fun setReminderProvider(provider: ReminderProvider)
     fun setNoteProvider(provider: NoteProvider)
     fun setNoteShortcut(shortcut: NoteShortcutType)
@@ -98,6 +102,17 @@ class PreferencesImpl(private val settings: Settings): Preferences {
         SecondaryMode.fromId(settings.getInt("ring_secondary_mode", SecondaryMode.Search.id))
     )
     override val secondaryMode = _secondaryMode.asStateFlow()
+
+    private val _primaryMode = MutableStateFlow(
+        PrimaryMode.fromId(settings.getInt("ring_primary_mode", PrimaryMode.IndexAgent.id))
+    )
+    override val primaryMode = _primaryMode.asStateFlow()
+
+    private val _shareWithIndexAgent = MutableStateFlow(
+        settings.getBoolean("ring_share_with_index_agent", false)
+    )
+    override val shareWithIndexAgent = _shareWithIndexAgent.asStateFlow()
+
     private val _reminderProvider = MutableStateFlow(
         settings.getInt("reminder_provider", ReminderProvider.Native.id)
             .let { ReminderProvider.fromId(it)!! }
@@ -181,6 +196,16 @@ class PreferencesImpl(private val settings: Settings): Preferences {
         _secondaryMode.value = mode
     }
 
+    override fun setPrimaryMode(mode: PrimaryMode) {
+        settings.putInt("ring_primary_mode", mode.id)
+        _primaryMode.value = mode
+    }
+
+    override fun setShareWithIndexAgent(value: Boolean) {
+        settings.putBoolean("ring_share_with_index_agent", value)
+        _shareWithIndexAgent.value = value
+    }
+
     override fun setReminderProvider(provider: ReminderProvider) {
         settings.putInt("reminder_provider", provider.id)
         _reminderProvider.value = provider
@@ -237,6 +262,17 @@ enum class SecondaryMode(val id: Int) {
     companion object {
         fun fromId(id: Int): SecondaryMode {
             return entries.firstOrNull { it.id == id } ?: Search
+        }
+    }
+}
+
+enum class PrimaryMode(val id: Int) {
+    IndexAgent(0),
+    Webhook(1);
+
+    companion object {
+        fun fromId(id: Int): PrimaryMode {
+            return entries.firstOrNull { it.id == id } ?: IndexAgent
         }
     }
 }

--- a/experimental/src/commonMain/kotlin/coredevices/ring/external/indexwebhook/IndexWebhookPreferences.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/external/indexwebhook/IndexWebhookPreferences.kt
@@ -40,6 +40,10 @@ class IndexWebhookPreferences(private val settings: Settings) {
     )
     val payloadMode = _payloadMode.asStateFlow()
 
+    /** True when both URL and auth token are configured (non-null, non-blank). */
+    val isLinked: Boolean
+        get() = !_webhookUrl.value.isNullOrBlank() && !_authToken.value.isNullOrBlank()
+
     fun setWebhookUrl(url: String?) {
         if (url != null) {
             settings.putString(URL_KEY, url)

--- a/experimental/src/commonMain/kotlin/coredevices/ring/service/recordings/button/RecordingOperation.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/service/recordings/button/RecordingOperation.kt
@@ -43,7 +43,8 @@ open class DefaultRecordingOperation(
     private val transferId: Long?,
     private val fileId: String,
     private val trace: RingTraceSession,
-    private val forcedTool: (suspend (messageText: String) -> ToolCallResult)?
+    private val forcedTool: (suspend (messageText: String) -> ToolCallResult)?,
+    private val runAgent: Boolean = true,
 ) : RecordingOperation, KoinComponent {
     companion object {
         private val logger = Logger.withTag("DefaultRecordingOperation")
@@ -117,10 +118,6 @@ open class DefaultRecordingOperation(
             }
         }
         coroutineScope {
-            val mcpSession = mcpSessionFactory.createForSandboxGroup(
-                mcpSandboxRepository.getDefaultGroupId(),
-                this
-            )
             val transcription = try {
                 trace.markEvent("transcription_start", TraceEventData.TranscriptionStart(
                     recordingId = recordingId,
@@ -189,47 +186,64 @@ open class DefaultRecordingOperation(
                 transcription.modelUsed
             )
 
-            try {
-                trace.markEvent("mcp_session_open_start", TraceEventData.RecordingEntryInfo(
+            if (runAgent) {
+                val mcpSession = mcpSessionFactory.createForSandboxGroup(
+                    mcpSandboxRepository.getDefaultGroupId(),
+                    this
+                )
+                try {
+                    trace.markEvent("mcp_session_open_start", TraceEventData.RecordingEntryInfo(
+                        entryId,
+                        recordingId,
+                        transferId ?: -1
+                    ))
+                    mcpSession.openSession()
+                    trace.markEvent("mcp_session_open_end", TraceEventData.RecordingEntryInfo(
+                        entryId,
+                        recordingId,
+                        transferId ?: -1
+                    ))
+                    logger.d { "Agent running..." }
+                    recordingEntryDao.updateRecordingEntryStatus(
+                        entryId,
+                        status = RecordingEntryStatus.agent_processing
+                    )
+                    recordingProcessor.processText(
+                        recordingId = recordingId,
+                        recordingEntryId = entryId,
+                        mcpSession = mcpSession,
+                        agent = chatAgent,
+                        forcedTool = forcedTool?.let { { it(transcription.text) } },
+                        text = transcription.text
+                    )
+                    logger.d { "Processing complete." }
+                    recordingEntryDao.updateRecordingEntryStatus(
+                        entryId,
+                        status = RecordingEntryStatus.completed
+                    )
+                } catch (e: Exception) {
+                    recordingEntryDao.updateRecordingEntryStatus(
+                        entryId,
+                        status = RecordingEntryStatus.agent_error,
+                        error = e.message
+                    )
+                    throw e
+                } finally {
+                    withTimeout(3.seconds) {
+                        mcpSession.closeSession()
+                    }
+                }
+            } else {
+                logger.d { "Skipping agent (runAgent=false); marking entry completed." }
+                trace.markEvent("agent_skipped", TraceEventData.RecordingEntryInfo(
                     entryId,
                     recordingId,
                     transferId ?: -1
                 ))
-                mcpSession.openSession()
-                trace.markEvent("mcp_session_open_end", TraceEventData.RecordingEntryInfo(
-                    entryId,
-                    recordingId,
-                    transferId ?: -1
-                ))
-                logger.d { "Agent running..." }
-                recordingEntryDao.updateRecordingEntryStatus(
-                    entryId,
-                    status = RecordingEntryStatus.agent_processing
-                )
-                recordingProcessor.processText(
-                    recordingId = recordingId,
-                    recordingEntryId = entryId,
-                    mcpSession = mcpSession,
-                    agent = chatAgent,
-                    forcedTool = forcedTool?.let { { it(transcription.text) } },
-                    text = transcription.text
-                )
-                logger.d { "Processing complete." }
                 recordingEntryDao.updateRecordingEntryStatus(
                     entryId,
                     status = RecordingEntryStatus.completed
                 )
-            } catch (e: Exception) {
-                recordingEntryDao.updateRecordingEntryStatus(
-                    entryId,
-                    status = RecordingEntryStatus.agent_error,
-                    error = e.message
-                )
-                throw e
-            } finally {
-                withTimeout(3.seconds) {
-                    mcpSession.closeSession()
-                }
             }
         }
     }

--- a/experimental/src/commonMain/kotlin/coredevices/ring/service/recordings/button/RecordingOperationFactory.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/service/recordings/button/RecordingOperationFactory.kt
@@ -1,11 +1,13 @@
 package coredevices.ring.service.recordings.button
 
+import coredevices.EnableExperimentalDevices
 import coredevices.indexai.agent.Agent
 import coredevices.mcp.data.ToolCallResult
 import coredevices.ring.agent.AgentFactory
 import coredevices.ring.agent.ChatMode
 import coredevices.ring.agent.McpSessionFactory
 import coredevices.ring.database.Preferences
+import coredevices.ring.database.PrimaryMode
 import coredevices.ring.database.SecondaryMode
 import coredevices.ring.database.room.repository.McpSandboxRepository
 import coredevices.ring.external.indexwebhook.IndexWebhookApi
@@ -13,6 +15,8 @@ import coredevices.ring.external.indexwebhook.IndexWebhookPreferences
 import coredevices.ring.service.ButtonPress
 import coredevices.ring.storage.RecordingStorage
 import coredevices.ring.util.trace.RingTraceSession
+import coredevices.util.Platform
+import coredevices.util.isIOS
 
 class RecordingOperationFactory(
     private val agentFactory: AgentFactory,
@@ -22,7 +26,9 @@ class RecordingOperationFactory(
     private val indexWebhookApi: IndexWebhookApi,
     private val indexWebhookPreferences: IndexWebhookPreferences,
     private val recordingStorage: RecordingStorage,
-    private val trace: RingTraceSession
+    private val trace: RingTraceSession,
+    private val platform: Platform,
+    private val enableExperimentalDevices: EnableExperimentalDevices,
 ) {
     companion object {
         private val secondaryOperationSequence = listOf(ButtonPress.Short, ButtonPress.Long)
@@ -42,14 +48,10 @@ class RecordingOperationFactory(
                 forcedTool = forcedNoteTool
             )
         } else {
-            DefaultRecordingOperation(
-                mcpSandboxRepository = mcpSandboxRepository,
-                mcpSessionFactory = mcpSessionFactory,
-                chatAgent = agentFactory.createForChatMode(ChatMode.Normal),
+            createPrimaryOperation(
                 recordingId = recordingId,
-                transferId = transferId,
                 fileId = fileId,
-                trace = trace,
+                transferId = transferId,
                 forcedTool = forcedNoteTool
             )
         }
@@ -69,6 +71,51 @@ class RecordingOperationFactory(
             text = text,
             forcedTool = forcedTool
         )
+    }
+
+    private fun createPrimaryOperation(
+        recordingId: Long,
+        transferId: Long?,
+        fileId: String,
+        forcedTool: (suspend (messageText: String) -> ToolCallResult)
+    ): RecordingOperation {
+        val eligibleForWebhookPrimary = platform.isIOS
+            && prefs.primaryMode.value == PrimaryMode.Webhook
+            && indexWebhookPreferences.isLinked
+            && enableExperimentalDevices.enabled.value
+
+        return if (eligibleForWebhookPrimary) {
+            IndexWebhookUploadRecordingOperation(
+                webhookApi = indexWebhookApi,
+                webhookPreferences = indexWebhookPreferences,
+                recordingStorage = recordingStorage,
+                fileId = fileId,
+                recordingId = recordingId,
+                decorated = DefaultRecordingOperation(
+                    mcpSandboxRepository = mcpSandboxRepository,
+                    mcpSessionFactory = mcpSessionFactory,
+                    chatAgent = agentFactory.createForChatMode(ChatMode.Normal),
+                    recordingId = recordingId,
+                    transferId = transferId,
+                    fileId = fileId,
+                    trace = trace,
+                    forcedTool = forcedTool,
+                    runAgent = prefs.shareWithIndexAgent.value,
+                ),
+            )
+        } else {
+            DefaultRecordingOperation(
+                mcpSandboxRepository = mcpSandboxRepository,
+                mcpSessionFactory = mcpSessionFactory,
+                chatAgent = agentFactory.createForChatMode(ChatMode.Normal),
+                recordingId = recordingId,
+                transferId = transferId,
+                fileId = fileId,
+                trace = trace,
+                forcedTool = forcedTool,
+                // runAgent defaults to true
+            )
+        }
     }
 
     private fun createSecondaryOperation(

--- a/experimental/src/commonMain/kotlin/coredevices/ring/ui/screens/settings/IndexSettings.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/ui/screens/settings/IndexSettings.kt
@@ -24,9 +24,12 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Headphones
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -67,6 +70,7 @@ import coredevices.ring.agent.integrations.GTasksIntegration
 import coredevices.ring.agent.integrations.NotionIntegration
 import coredevices.ring.database.MusicControlMode
 import coredevices.ring.database.Preferences
+import coredevices.ring.database.PrimaryMode
 import coredevices.ring.database.SecondaryMode
 import coredevices.ring.external.indexwebhook.IndexWebhookSettingsDialog
 import coredevices.ring.external.indexwebhook.IndexWebhookSettingsViewModel
@@ -119,6 +123,9 @@ fun IndexSettings(coreNav: CoreNav) {
     val preferences = koinInject<Preferences>()
     val musicControlMode by viewModel.musicControlMode.collectAsState()
     val secondaryMode by viewModel.secondaryMode.collectAsState()
+    val showPrimaryModeDialog by viewModel.showPrimaryModeDialog.collectAsState()
+    val primaryMode by viewModel.primaryMode.collectAsState()
+    val shareWithIndexAgent by viewModel.shareWithIndexAgent.collectAsState()
     val noteShortcut by viewModel.noteShortcut.collectAsState()
     var showSignInDialog by remember { mutableStateOf(false) }
     var showBackupDialog by remember { mutableStateOf(false) }
@@ -165,6 +172,27 @@ fun IndexSettings(coreNav: CoreNav) {
             },
             webhookEnabled = webhookIsLinked,
             webhookShown = experimentalDevicesEnabled
+        )
+    }
+    if (showPrimaryModeDialog) {
+        PrimaryModeDialog(
+            currentMode = primaryMode,
+            webhookLinked = webhookIsLinked,
+            shareWithIndexAgent = shareWithIndexAgent,
+            onModeSelected = { newMode ->
+                viewModel.setPrimaryMode(newMode)
+                viewModel.closePrimaryModeDialog()
+            },
+            onShareToggle = { newValue ->
+                viewModel.setShareWithIndexAgent(newValue)
+            },
+            onConfigureWebhook = {
+                viewModel.closePrimaryModeDialog()
+                webhookViewModel.openDialog()
+            },
+            onDismissRequest = {
+                viewModel.closePrimaryModeDialog()
+            },
         )
     }
     if (showNoteShortcutDialog) {
@@ -296,6 +324,25 @@ fun IndexSettings(coreNav: CoreNav) {
                         )
                     }
                 )
+            }
+            if (platform.isIOS && experimentalDevicesEnabled) {
+                item {
+                    ListItem(
+                        modifier = Modifier.clickable {
+                            viewModel.showPrimaryModeDialog()
+                        },
+                        headlineContent = { Text("Single click and hold") },
+                        supportingContent = {
+                            Text(
+                                when (primaryMode) {
+                                    PrimaryMode.IndexAgent -> "Index Agent"
+                                    PrimaryMode.Webhook -> if (webhookIsLinked) "Webhook"
+                                                          else "Webhook (not configured)"
+                                }
+                            )
+                        }
+                    )
+                }
             }
             item {
                 ListItem(
@@ -698,6 +745,130 @@ fun SecondaryModeDialog(
                 }
             }
         }
+    }
+}
+
+@Composable
+fun PrimaryModeDialog(
+    currentMode: PrimaryMode,
+    webhookLinked: Boolean,
+    shareWithIndexAgent: Boolean,
+    onModeSelected: (PrimaryMode) -> Unit,
+    onShareToggle: (Boolean) -> Unit,
+    onConfigureWebhook: () -> Unit,
+    onDismissRequest: () -> Unit,
+) {
+    var targetMode by remember { mutableStateOf(currentMode) }
+    var showInfoDialog by remember { mutableStateOf(false) }
+
+    M3Dialog(
+        onDismissRequest = onDismissRequest,
+        icon = { Icon(Icons.Default.Settings, contentDescription = null) },
+        title = { Text("Single Click and Hold") },
+        buttons = {
+            TextButton(onClick = onDismissRequest) { Text("Cancel") }
+            TextButton(onClick = { onModeSelected(targetMode) }) { Text("OK") }
+        }
+    ) {
+        LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            item(PrimaryMode.IndexAgent) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable {
+                            targetMode = PrimaryMode.IndexAgent
+                        }
+                ) {
+                    RadioButton(
+                        selected = targetMode == PrimaryMode.IndexAgent,
+                        onClick = { targetMode = PrimaryMode.IndexAgent },
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    Column {
+                        Text("Index Agent")
+                        Text(
+                            "Transcribe and send to the Index agent. This is the original behavior.",
+                            fontSize = 12.sp,
+                        )
+                    }
+                }
+            }
+            item(PrimaryMode.Webhook) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable(enabled = webhookLinked) {
+                            targetMode = PrimaryMode.Webhook
+                        }
+                ) {
+                    RadioButton(
+                        selected = targetMode == PrimaryMode.Webhook,
+                        onClick = { targetMode = PrimaryMode.Webhook },
+                        enabled = webhookLinked,
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    Column {
+                        Text("Webhook")
+                        Text(
+                            "Transcribe and send to your webhook.",
+                            fontSize = 12.sp,
+                        )
+                        if (!webhookLinked) {
+                            TextButton(onClick = onConfigureWebhook) {
+                                Text("Configure Webhook")
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (targetMode != PrimaryMode.IndexAgent) {
+                item("share_toggle") {
+                    Spacer(Modifier.height(12.dp))
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { onShareToggle(!shareWithIndexAgent) }
+                    ) {
+                        Checkbox(
+                            checked = shareWithIndexAgent,
+                            onCheckedChange = onShareToggle,
+                        )
+                        Spacer(Modifier.width(8.dp))
+                        Column(modifier = Modifier.weight(1f)) {
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                Text("Share with Index agent")
+                                Spacer(Modifier.width(4.dp))
+                                IconButton(onClick = { showInfoDialog = true }) {
+                                    Icon(Icons.Default.Info, contentDescription = "What does this do?")
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (showInfoDialog) {
+        AlertDialog(
+            onDismissRequest = { showInfoDialog = false },
+            confirmButton = {
+                TextButton(onClick = { showInfoDialog = false }) { Text("Got it") }
+            },
+            title = { Text("Share with Index agent") },
+            text = {
+                Text(
+                    "When on, your transcription also appears in the Index feed and the " +
+                    "on-device agent processes it (creates notes, runs tools, and so on). " +
+                    "When off, the transcription is sent only to your destination — it still " +
+                    "shows in the feed as a raw transcript, but the agent does not run on it."
+                )
+            }
+        )
     }
 }
 

--- a/experimental/src/commonMain/kotlin/coredevices/ring/ui/viewmodel/SettingsViewModel.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/ui/viewmodel/SettingsViewModel.kt
@@ -13,6 +13,7 @@ import coredevices.ring.api.NotionApi
 import coredevices.ring.data.NoteShortcutType
 import coredevices.ring.database.MusicControlMode
 import coredevices.ring.database.Preferences
+import coredevices.ring.database.PrimaryMode
 import coredevices.ring.database.SecondaryMode
 import coredevices.ring.database.firestore.dao.FirestoreRecordingsDao
 import coredevices.ring.database.room.repository.RecordingRepository
@@ -108,6 +109,10 @@ class SettingsViewModel(
     private val _showSecondaryModeDialog = MutableStateFlow(false)
     val showSecondaryModeDialog = _showSecondaryModeDialog.asStateFlow()
     val secondaryMode = preferences.secondaryMode
+    private val _showPrimaryModeDialog = MutableStateFlow(false)
+    val showPrimaryModeDialog = _showPrimaryModeDialog.asStateFlow()
+    val primaryMode = preferences.primaryMode
+    val shareWithIndexAgent = preferences.shareWithIndexAgent
     private val _showNoteShortcutDialog = MutableStateFlow(false)
     val showNoteShortcutDialog = _showNoteShortcutDialog.asStateFlow()
     val noteShortcut = preferences.noteShortcut
@@ -180,6 +185,22 @@ class SettingsViewModel(
 
     fun setSecondaryMode(mode: SecondaryMode) {
         preferences.setSecondaryMode(mode)
+    }
+
+    fun showPrimaryModeDialog() {
+        _showPrimaryModeDialog.value = true
+    }
+
+    fun closePrimaryModeDialog() {
+        _showPrimaryModeDialog.value = false
+    }
+
+    fun setPrimaryMode(mode: PrimaryMode) {
+        preferences.setPrimaryMode(mode)
+    }
+
+    fun setShareWithIndexAgent(value: Boolean) {
+        preferences.setShareWithIndexAgent(value)
     }
 
     fun toggleDebugDetailsEnabled() {


### PR DESCRIPTION
## Summary

Adds an iOS-only "Single click and hold" primary-mode picker. Experimental users can now choose between today's Index Agent behavior (default, unchanged) and a Webhook-only mode that skips the on-device agent. A "Share with Index agent" toggle re-enables the agent inside Webhook mode for users who want both.

## Motivation

Today the ring's primary gesture (single click and hold) is hardcoded to route every recording through the Index agent. Every transcription appears in the Index feed and is processed by the on-device LLM, which frequently generates low-value notes. Users have no way to opt an individual recording — or all primary-gesture recordings — out of this flow.

The double click and hold offers more options, but I'd like both single click and double click to be configurable. This PR extends the same underlying `IndexWebhookUploadRecordingOperation` to the primary gesture, behind the same `experimentalDevicesEnabled` gate, and adds a user-toggleable "Share with Index agent" flag that controls whether the agent runs on top of the webhook upload.

## Scope

**iOS only.** All UI additions are wrapped in `platform.isIOS && experimentalDevicesEnabled`. The factory-layer eligibility check is also platform-gated, so Android users get zero behavior change. Existing secondary-mode Webhook behavior (on either platform) is untouched.

**Default on upgrade:** `PrimaryMode.IndexAgent`, `shareWithIndexAgent = false`. Existing users see no UI or behavior change until they explicitly opt in.

## Changes

- `Preferences.kt`: new `PrimaryMode` enum, two new `StateFlow`s and setters, alongside existing `SecondaryMode` pattern.
- `IndexWebhookPreferences.kt`: new `isLinked` computed property.
- `RecordingOperation.kt`: `DefaultRecordingOperation` gains a `runAgent: Boolean = true` param. When false, the MCP session setup and agent invocation are skipped; transcription and entry persistence are unchanged.
- `RecordingOperationFactory.kt`: primary-gesture dispatch extracted into `createPrimaryOperation` with a four-guard eligibility check.
- `SettingsViewModel.kt`: mirrors existing `secondaryMode` exposure for the new prefs.
- `IndexSettings.kt`: new iOS-only row, new `PrimaryModeDialog` composable with Index Agent / Webhook radios, conditional Share-with-Index-agent toggle with info tooltip.

No Room migrations, no new dependencies, no new files.

## Test plan

- [ ] On iOS with `experimentalDevices = true`: Settings shows the new "Single click and hold" row above "Double click and hold". Subtitle reads "Index Agent" by default.
- [ ] Without a webhook configured, the Webhook radio is disabled and shows "Configure Webhook" button that opens the existing webhook dialog.
- [ ] With a webhook configured, selecting Webhook enables the radio; the Share-with-Index-agent toggle appears below, default OFF.
- [ ] Single click and hold gesture with Webhook + Share OFF: transcription fires webhook, no note created, recording entry still appears in feed with transcription.
- [ ] Single click and hold gesture with Webhook + Share ON: transcription fires webhook AND agent runs (notes may be created as before).
- [ ] iOS without `experimentalDevices`: "Single click and hold" row is not visible. No behavior change.
- [ ] Android with any combination: "Single click and hold" row is not visible. No behavior change.

## Notes

No tests added. Existing test suite is Android-only and would not validate iOS-specific behavior. Happy to add `commonTest` tests for the `PrimaryMode.fromId` fallback and `Preferences` round-trip if preferred.