### PR TITLE
Android: Enable VoIP calls for InCallService

### DIFF
--- a/libpebble3/src/androidMain/AndroidManifest.xml
+++ b/libpebble3/src/androidMain/AndroidManifest.xml
@@ -61,6 +61,9 @@
             android:name="io.rebble.libpebblecommon.calls.LibPebbleInCallService"
             android:exported="true"
             android:permission="android.permission.BIND_INCALL_SERVICE">
+            <meta-data
+                android:name="android.telecom.INCLUDE_SELF_MANAGED_CALLS"
+                android:value="true" />
             <intent-filter>
                 <action android:name="android.telecom.InCallService" />
             </intent-filter>


### PR DESCRIPTION
This allows Google Voice VoIP ("self-managed") calls to appear on the watch. The button to answer a call isn't present, which I think may be a limitation on the Google Voice side.