### PR TITLE
Respect obfuscateContent toggle in PKJS console logs

### DIFF
--- a/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/di/PKJSModule.android.kt
+++ b/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/di/PKJSModule.android.kt
@@ -22,6 +22,7 @@ actual val pkjsPlatformModule: Module = module {
             logMessages = params.get(),
             remoteTimelineEmulator = get(),
             httpInterceptorManager = get(),
+            notificationConfigFlow = get(),
         )
     } bind JsRunner::class
 }

--- a/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/js/WebViewJsRunner.kt
+++ b/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/js/WebViewJsRunner.kt
@@ -22,6 +22,7 @@ import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.core.net.toUri
 import co.touchlab.kermit.Logger
+import io.rebble.libpebblecommon.NotificationConfigFlow
 import io.rebble.libpebblecommon.connection.AppContext
 import io.rebble.libpebblecommon.connection.LibPebble
 import io.rebble.libpebblecommon.database.entity.LockerEntry
@@ -59,6 +60,7 @@ class WebViewJsRunner(
     logMessages: Channel<String>,
     remoteTimelineEmulator: RemoteTimelineEmulator,
     httpInterceptorManager: HttpInterceptorManager,
+    notificationConfigFlow: NotificationConfigFlow,
 ): JsRunner(appInfo, lockerEntry, jsPath, device, urlOpenRequests), LibPebbleKoinComponent {
     private val context = appContext.context
     companion object {
@@ -71,7 +73,7 @@ class WebViewJsRunner(
     private var webView: WebView? = null
     private val initializedLock = Object()
     private val publicJsInterface = WebViewPKJSInterface(this, device, context, libPebble, jsTokenUtil)
-    private val privateJsInterface = WebViewPrivatePKJSInterface(this, device, scope, _outgoingAppMessages, logMessages, jsTokenUtil, remoteTimelineEmulator, httpInterceptorManager)
+    private val privateJsInterface = WebViewPrivatePKJSInterface(this, device, scope, _outgoingAppMessages, logMessages, jsTokenUtil, remoteTimelineEmulator, httpInterceptorManager, notificationConfigFlow)
     private val localStorageInterface = WebViewJSLocalStorageInterface(appInfo.uuid, appContext) {
         runBlocking(Dispatchers.Main) {
             webView?.evaluateJavascript(

--- a/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/js/WebViewPrivatePKJSInterface.kt
+++ b/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/js/WebViewPrivatePKJSInterface.kt
@@ -4,6 +4,7 @@ import android.net.Uri
 import android.webkit.JavascriptInterface
 import androidx.core.net.toUri
 import co.touchlab.kermit.Logger
+import io.rebble.libpebblecommon.NotificationConfigFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -19,7 +20,8 @@ class WebViewPrivatePKJSInterface(
     jsTokenUtil: JsTokenUtil,
     remoteTimelineEmulator: RemoteTimelineEmulator,
     httpInterceptorManager: HttpInterceptorManager,
-): PrivatePKJSInterface(jsRunner, device, scope, outgoingAppMessages, logMessages, jsTokenUtil, remoteTimelineEmulator, httpInterceptorManager) {
+    notificationConfigFlow: NotificationConfigFlow,
+): PrivatePKJSInterface(jsRunner, device, scope, outgoingAppMessages, logMessages, jsTokenUtil, remoteTimelineEmulator, httpInterceptorManager, notificationConfigFlow) {
 
     companion object {
         private val logger = Logger.withTag(WebViewPrivatePKJSInterface::class.simpleName!!)

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/js/PrivatePKJSInterface.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/js/PrivatePKJSInterface.kt
@@ -3,6 +3,7 @@ package io.rebble.libpebblecommon.js
 import co.touchlab.kermit.Logger
 import io.rebble.cobble.shared.data.js.ActivePebbleWatchInfo
 import io.rebble.cobble.shared.data.js.fromWatchInfo
+import io.rebble.libpebblecommon.NotificationConfigFlow
 import io.rebble.libpebblecommon.services.appmessage.AppMessageResult
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -31,6 +32,7 @@ abstract class PrivatePKJSInterface(
     private val jsTokenUtil: JsTokenUtil,
     private val remoteTimelineEmulator: RemoteTimelineEmulator,
     private val httpInterceptorManager: HttpInterceptorManager,
+    private val notificationConfigFlow: NotificationConfigFlow,
 ) {
     companion object {
         private val logger = Logger.withTag("PrivatePKJSInterface")
@@ -46,12 +48,11 @@ abstract class PrivatePKJSInterface(
 
     open fun onConsoleLog(level: String, message: String, source: String?) {
         logger.i {
-            val containsSensitiveInfo = sensitiveTerms.any { term ->
-                message.contains(term, ignoreCase = true)
-            }
+            val redact = notificationConfigFlow.value.obfuscateContent &&
+                sensitiveTerms.any { term -> message.contains(term, ignoreCase = true) }
             buildString {
                 append("[PKJS:${level.uppercase()}] \"")
-                if (containsSensitiveInfo) {
+                if (redact) {
                     append("<REDACTED>")
                 } else {
                     append(message)

--- a/libpebble3/src/iosMain/kotlin/io/rebble/libpebblecommon/di/PKJSModule.ios.kt
+++ b/libpebble3/src/iosMain/kotlin/io/rebble/libpebblecommon/di/PKJSModule.ios.kt
@@ -22,6 +22,7 @@ actual val pkjsPlatformModule: Module = module {
             logMessages = params.get(),
             remoteTimelineEmulator = get(),
             httpInterceptorManager = get(),
+            notificationConfigFlow = get(),
         )
     } bind JsRunner::class
 }

--- a/libpebble3/src/iosMain/kotlin/io/rebble/libpebblecommon/js/JSCPrivatePKJSInterface.kt
+++ b/libpebble3/src/iosMain/kotlin/io/rebble/libpebblecommon/js/JSCPrivatePKJSInterface.kt
@@ -1,6 +1,7 @@
 package io.rebble.libpebblecommon.js
 
 import co.touchlab.kermit.Logger
+import io.rebble.libpebblecommon.NotificationConfigFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -16,7 +17,8 @@ class JSCPrivatePKJSInterface(
     jsTokenUtil: JsTokenUtil,
     remoteTimelineEmulator: RemoteTimelineEmulator,
     httpInterceptorManager: HttpInterceptorManager,
-): PrivatePKJSInterface(jsRunner, device, scope, outgoingAppMessages, logMessages, jsTokenUtil, remoteTimelineEmulator, httpInterceptorManager), RegisterableJsInterface {
+    notificationConfigFlow: NotificationConfigFlow,
+): PrivatePKJSInterface(jsRunner, device, scope, outgoingAppMessages, logMessages, jsTokenUtil, remoteTimelineEmulator, httpInterceptorManager, notificationConfigFlow), RegisterableJsInterface {
     private val logger = Logger.withTag("JSCPrivatePKJSInterface")
 
     override val interf = mapOf(

--- a/libpebble3/src/iosMain/kotlin/io/rebble/libpebblecommon/js/JavascriptCoreJsRunner.kt
+++ b/libpebble3/src/iosMain/kotlin/io/rebble/libpebblecommon/js/JavascriptCoreJsRunner.kt
@@ -1,6 +1,7 @@
 package io.rebble.libpebblecommon.js
 
 import co.touchlab.kermit.Logger
+import io.rebble.libpebblecommon.NotificationConfigFlow
 import io.rebble.libpebblecommon.connection.AppContext
 import io.rebble.libpebblecommon.connection.LibPebble
 import io.rebble.libpebblecommon.database.entity.LockerEntry
@@ -48,6 +49,7 @@ class JavascriptCoreJsRunner(
     private val logMessages: Channel<String>,
     private val remoteTimelineEmulator: RemoteTimelineEmulator,
     private val httpInterceptorManager: HttpInterceptorManager,
+    private val notificationConfigFlow: NotificationConfigFlow,
 ): JsRunner(appInfo, lockerEntry, jsPath, device, urlOpenRequests) {
     private var jsContext: JSContext? = null
     private val logger = Logger.withTag("JSCRunner-${appInfo.longName}")
@@ -76,7 +78,7 @@ class JavascriptCoreJsRunner(
             JSTimeout(interfacesScope, evalRawFn),
             WebSocketManager(interfacesScope, evalFn),
             JSCPKJSInterface(this, device, libPebble, jsTokenUtil),
-            JSCPrivatePKJSInterface(jsPath, this, device, interfacesScope, _outgoingAppMessages, logMessages, jsTokenUtil, remoteTimelineEmulator, httpInterceptorManager),
+            JSCPrivatePKJSInterface(jsPath, this, device, interfacesScope, _outgoingAppMessages, logMessages, jsTokenUtil, remoteTimelineEmulator, httpInterceptorManager, notificationConfigFlow),
             JSCJSLocalStorageInterface(jsContext, appInfo.uuid, appContext, evalRawFn),
             JSCGeolocationInterface(interfacesScope, this)
         )


### PR DESCRIPTION
Proposed fix for #163.

You don't have to take it in this shape if you don't like the approach claude took, feel free to close it in that case, probably is faster for you to do the change in the manner you prefer rather than to explain to me how you want it done.

This is quite a bit more complex than the other places that have to deal with log cleanup due to how PKJS is wired up in general.