### PR TITLE
 Enable Timeline insertion from PebbleKit2 

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,7 @@ kotlinx-datetime = "0.7.1"
 koin = "4.1.1"
 atomicfu = "0.29.0"
 compose-multiplatform = "1.10.1"
-pebblekit = "09f86ee72b"
+pebblekit = "1.1.0"
 settings = "1.3.0"
 kable = "0.42.0"
 kmpio = "0.3.0"
@@ -118,7 +118,7 @@ kotlinx-io-okio = { module = "org.jetbrains.kotlinx:kotlinx-io-okio", version.re
 koin-core = { group = "io.insert-koin", name = "koin-core", version.ref = "koin" }
 koin-compose = { group = "io.insert-koin", name = "koin-compose", version.ref = "koin" }
 koin-compose-viewmodel = { group = "io.insert-koin", name = "koin-compose-viewmodel", version.ref = "koin" }
-pebblekit = { module = "com.github.pebble-dev:PebbleKitAndroid2", version.ref = "pebblekit" }
+pebblekit = { module = "io.rebble.pebblekit2:server", version.ref = "pebblekit" }
 settings = { group = "com.russhwolf", name = "multiplatform-settings-no-arg", version.ref = "settings" }
 settings-test = { group = "com.russhwolf", name = "multiplatform-settings-test", version.ref = "settings" }
 settings-serialization = { group = "com.russhwolf", name = "multiplatform-settings-serialization", version.ref = "settings" }

--- a/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/pebblekit/two/PebbleKit2.kt
+++ b/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/pebblekit/two/PebbleKit2.kt
@@ -199,9 +199,9 @@ private fun AppMessageDictionary.toPebbleDictionary(): PebbleDictionary {
     return map {
         val key = it.key.toUInt()
         val value = when (val rawValue = it.value) {
-            is String -> PebbleDictionaryItem.String(rawValue)
-            is UByteArray -> PebbleDictionaryItem.ByteArray(rawValue.toByteArray())
-            is ByteArray -> PebbleDictionaryItem.ByteArray(rawValue)
+            is String -> PebbleDictionaryItem.Text(rawValue)
+            is UByteArray -> PebbleDictionaryItem.Bytes(rawValue.toByteArray())
+            is ByteArray -> PebbleDictionaryItem.Bytes(rawValue)
             is Int -> PebbleDictionaryItem.Int32(rawValue)
             is Long -> PebbleDictionaryItem.Int32(rawValue.toInt())
             is ULong -> PebbleDictionaryItem.UInt32(rawValue.toUInt())

--- a/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/pebblekit/two/PebbleSenderReceiver.kt
+++ b/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/pebblekit/two/PebbleSenderReceiver.kt
@@ -2,20 +2,34 @@ package io.rebble.libpebblecommon.pebblekit.two
 
 import io.rebble.libpebblecommon.connection.ConnectedPebbleDevice
 import io.rebble.libpebblecommon.connection.LibPebble
+import io.rebble.libpebblecommon.connection.LockerApi
 import io.rebble.libpebblecommon.connection.Watches
 import io.rebble.libpebblecommon.di.LibPebbleCoroutineScope
 import io.rebble.libpebblecommon.di.LibPebbleKoinComponent
+import io.rebble.libpebblecommon.disk.pbw.PbwApp
+import io.rebble.libpebblecommon.js.RemoteTimelineEmulator
+import io.rebble.libpebblecommon.js.TimelineLayoutJson
+import io.rebble.libpebblecommon.js.TimelinePinJson
+import io.rebble.libpebblecommon.locker.Locker
+import io.rebble.libpebblecommon.locker.LockerPBWCache
 import io.rebble.libpebblecommon.services.appmessage.AppMessageResult
 import io.rebble.pebblekit2.common.model.PebbleDictionary
+import io.rebble.pebblekit2.common.model.TimelinePin
+import io.rebble.pebblekit2.common.model.TimelineResult
 import io.rebble.pebblekit2.common.model.TransmissionResult
 import io.rebble.pebblekit2.common.model.WatchIdentifier
 import io.rebble.pebblekit2.server.BasePebbleSenderReceiver
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.withTimeout
 import java.util.UUID
+import kotlin.collections.mapNotNull
+import kotlin.collections.orEmpty
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.toKotlinDuration
+import kotlin.time.toKotlinInstant
 import kotlin.uuid.toJavaUuid
 import kotlin.uuid.toKotlinUuid
 
@@ -23,6 +37,9 @@ private val WATCH_SENDING_TIMEOUT = 10.seconds
 
 class PebbleSenderReceiver : BasePebbleSenderReceiver(), LibPebbleKoinComponent {
     private val watchManager: Watches = getKoin().get<LibPebble>()
+    private val locker: Locker = getKoin().get()
+    private val lockerPBWCache: LockerPBWCache = getKoin().get()
+    private val remoteTimelineEmulator: RemoteTimelineEmulator = getKoin().get()
     override val coroutineScope: LibPebbleCoroutineScope = getKoin().get()
 
     override suspend fun sendDataToPebble(
@@ -68,6 +85,36 @@ class PebbleSenderReceiver : BasePebbleSenderReceiver(), LibPebbleKoinComponent 
         }
     }
 
+    override suspend fun insertTimelinePin(
+        callingPackage: String?,
+        watchappUUID: UUID,
+        timelinePin: TimelinePin
+    ): TimelineResult {
+        if (!isAllowedToCommunicate(callingPackage, watchappUUID)) {
+            return TimelineResult.FailedNoPermissions
+        }
+
+        remoteTimelineEmulator.insertPin(watchappUUID.toKotlinUuid(), timelinePin.toPinJson())
+        return TimelineResult.Success
+    }
+
+    override suspend fun deleteTimelinePin(
+        callingPackage: String?,
+        watchappUUID: UUID,
+        id: String
+    ): TimelineResult {
+        if (!isAllowedToCommunicate(callingPackage, watchappUUID)) {
+            return TimelineResult.FailedNoPermissions
+        }
+
+        val success = remoteTimelineEmulator.deletePin(watchappUUID.toKotlinUuid(), id)
+        return if (success) {
+            TimelineResult.Success
+        } else {
+            TimelineResult.FailedUnknownPin
+        }
+    }
+
     private inline suspend fun runOnConnectedWatches(
         watches: List<WatchIdentifier>?,
         crossinline action: suspend (ConnectedPebbleDevice) -> TransmissionResult
@@ -97,4 +144,44 @@ class PebbleSenderReceiver : BasePebbleSenderReceiver(), LibPebbleKoinComponent 
             }.mapValues { it.value.await() }
         }
     }
+
+    private suspend fun isAllowedToCommunicate(pkg: String?, uuid: UUID): Boolean {
+        if (pkg == null) {
+            return false
+        }
+
+        val lockerEntry = locker.getLockerApp(uuid.toKotlinUuid()).firstOrNull() ?: return false
+        val pbwInfo = PbwApp(
+            lockerPBWCache.getPBWFileForApp(
+                lockerEntry.properties.id,
+                lockerEntry.properties.version.orEmpty(),
+                locker
+            )
+        )
+
+        return pbwInfo.info.companionApp?.android?.apps.orEmpty().any { it.pkg == pkg }
+    }
+}
+
+private fun TimelinePin.toPinJson(): TimelinePinJson {
+    return TimelinePinJson(
+        id,
+        startTime,
+        duration?.inWholeMinutes?.toInt(),
+        layout = TimelineLayoutJson(
+            type  = layout.type.code,
+            title = layout.title,
+            subtitle = layout.subtitle,
+            body = layout.body,
+            tinyIcon = layout.tinyIcon,
+            smallIcon = layout.smallIcon,
+            largeIcon = layout.largeIcon,
+            primaryColor = layout.primaryColor,
+            secondaryColor = layout.secondaryColor,
+            backgroundColor = layout.backgroundColor,
+            headings = layout.headings,
+            paragraphs = layout.paragraphs,
+            lastUpdated = layout.lastUpdated,
+        )
+    )
 }

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/js/RemoteTimelineEmulator.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/js/RemoteTimelineEmulator.kt
@@ -82,10 +82,14 @@ class RemoteTimelineEmulator(
             return
         }
 //        logger.v { "insertPin: pin=$pin" }
+        insertPin(appUuid, pin)
+    }
+
+    suspend fun insertPin(appUuid: Uuid, pin: TimelinePinJson) {
         val existingPin = timelinePinRealDao.getPinsForWatchapp(appUuid).find { it.backingId == pin.id }
         val pinUuid = existingPin?.itemId ?: Uuid.random()
         val timelinePin = asPin(jsonPin = pin, appUuid = appUuid, pinUuid = pinUuid)
-//        logger.v { "insertPin: timelinePin=$timelinePin" }
+        //        logger.v { "insertPin: timelinePin=$timelinePin" }
         if (timelinePin == null) {
             logger.w { "insert pin == null" }
             return
@@ -100,14 +104,15 @@ class RemoteTimelineEmulator(
         }
     }
 
-    suspend fun deletePin(appUuid: Uuid, pinIdentifier: String) {
+    suspend fun deletePin(appUuid: Uuid, pinIdentifier: String): Boolean {
         logger.v { "deletePin: pinIdentifier=$pinIdentifier" }
         val existingPin = timelinePinRealDao.getPinsForWatchapp(appUuid).find { it.backingId == pinIdentifier }
         if (existingPin == null) {
             logger.i { "deletePin: Unknown pin identifier: $pinIdentifier" }
-            return
+            return false
         }
         timelinePinRealDao.markForDeletionWithReminders(existingPin.itemId, timelineReminderRealDao)
+        return true
     }
 
     companion object {


### PR DESCRIPTION
New PebbleKit2 allows apps to insert/delete timeline pins.

This PR adds this functionality to the LibPebble 3 side. It reuses existing `RemoteTimelineEmulator`.