### PR TITLE
Add Gentle vibe option to WatchPrefEntity

### DIFF
--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/database/entity/WatchPrefEntity.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/database/entity/WatchPrefEntity.kt
@@ -320,6 +320,7 @@ enum class VibeScore(override val code: UByte, override val displayName: String)
     Reveille(11u, "Reveille"),
     Mario(12u, "Mario"),
     AlarmsLPM(13u, "ALARMS LPM"),
+    Gentle(14u, "Gentle"),
 }
 
 enum class MenuScrollVibeBehaviour(override val code: UByte, override val displayName: String) : WatchPrefEnum {
@@ -425,6 +426,7 @@ enum class EnumWatchPref(
             VibeScore.Jackhammer,
             VibeScore.Reveille,
             VibeScore.Mario,
+            VibeScore.Gentle,
         ),
     ),
     MenuScrollVibe(


### PR DESCRIPTION
This is related to my other PR: https://github.com/coredevices/PebbleOS/pull/1194

Haven't tested it, but I searched the codebase for "Reveille" and this file was the only one found, so hoping such a small change is still useful and easily tested by someone who has full setup for building Android and iOS.

I'm assuming the number values correspond to the ones defined here:
https://github.com/coredevices/PebbleOS/blob/82db2b25cfc0e3cc49436401917a300b5752a65f/src/fw/services/vibes/vibes.def#L4-L15