### PR TITLE
Add support for getafix DVT2 (platform 21)

### DIFF
--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/metadata/WatchHardwarePlatform.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/metadata/WatchHardwarePlatform.kt
@@ -40,6 +40,7 @@ enum class WatchHardwarePlatform(val protocolNumber: UByte, private val _watchTy
     CORE_OBELIX_PVT(18u, WatchType.EMERY, "obelix_pvt"),
     CORE_GETAFIX_EVT(19u, WatchType.GABBRO, "getafix_evt"),
     CORE_GETAFIX_DVT(20u, WatchType.GABBRO, "getafix_dvt"),
+    CORE_GETAFIX_DVT2(21u, WatchType.GABBRO, "getafix_dvt2"),
     PEBBLE_SILK_BIGBOARD(250u, WatchType.DIORITE, "silk_bb"),
     PEBBLE_SILK_BIGBOARD_2_PLUS(248u, WatchType.DIORITE, "silk_bb2"),
     PEBBLE_ROBERT_EVT(13u, WatchType.EMERY, "robert_evt"),


### PR DESCRIPTION
## Summary
- Adds `CORE_GETAFIX_DVT2` to `WatchHardwarePlatform` (protocol number 21, `getafix_dvt2`, GABBRO watch type), following the existing Getafix EVT/DVT pattern.

Fixes MOB-6986.

## Test plan
- [ ] Confirm a getafix DVT2 unit connects and reports its hardware revision as `getafix_dvt2` (resolved to `CORE_GETAFIX_DVT2`/GABBRO) rather than `UNKNOWN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)