### PR TITLE
Implement sending typical steps to the watch

### DIFF
--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/connection/FakeLibPebble.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/connection/FakeLibPebble.kt
@@ -379,7 +379,8 @@ class FakeLibPebble : LibPebble {
             todaySteps = 0L,
             lastNightSleepHours = null,
             latestDataTimestamp = null,
-            daysOfData = 0
+            daysOfData = 0,
+            weekdayTypicalSteps = emptyMap(),
         )
     }
 

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/health/Health.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/health/Health.kt
@@ -19,6 +19,8 @@ import io.rebble.libpebblecommon.datalogging.HealthDataProcessor
 import io.rebble.libpebblecommon.di.LibPebbleCoroutineScope
 import io.rebble.libpebblecommon.services.DailySleep
 import io.rebble.libpebblecommon.services.calculateHealthAverages
+import io.rebble.libpebblecommon.services.computeAllWeekdayTypicalSteps
+import io.rebble.libpebblecommon.services.decodeTypicalStepTotal
 import io.rebble.libpebblecommon.services.groupSleepSessions
 import io.rebble.libpebblecommon.services.fetchAndGroupDailySleep
 import io.rebble.libpebblecommon.services.updateHealthStatsInDatabase
@@ -94,6 +96,9 @@ class Health(
         val lastNightSleepHours =
             if (lastNightSleepSeconds > 0) lastNightSleepSeconds / 3600f else null
 
+        val weekdayTypicalSteps = computeAllWeekdayTypicalSteps(healthDao, today, timeZone)
+            .mapValues { (_, payload) -> decodeTypicalStepTotal(payload) }
+
         return HealthDebugStats(
             totalSteps30Days = averages.totalSteps,
             averageStepsPerDay = averages.averageStepsPerDay,
@@ -102,7 +107,8 @@ class Health(
             todaySteps = todaySteps,
             lastNightSleepHours = lastNightSleepHours,
             latestDataTimestamp = latestTimestamp,
-            daysOfData = daysOfData
+            daysOfData = daysOfData,
+            weekdayTypicalSteps = weekdayTypicalSteps,
         )
     }
 

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/health/HealthRecords.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/health/HealthRecords.kt
@@ -77,6 +77,10 @@ class RawOverlayRecord : StructMappable() {
 
 /**
  * Debug statistics for health data, used for diagnostics and testing.
+ *
+ * [weekdayTypicalSteps] carries the per-weekday typical-step totals computed for the
+ * `<weekday>_steps` BlobDB rows; absent keys are weekdays where the user has insufficient
+ * same-weekday history (we don't write a row for them, so the watch shows no comparison).
  */
 data class HealthDebugStats(
     val totalSteps30Days: Long,
@@ -86,5 +90,6 @@ data class HealthDebugStats(
     val todaySteps: Long,
     val lastNightSleepHours: Float?,
     val latestDataTimestamp: Long?,
-    val daysOfData: Int
+    val daysOfData: Int,
+    val weekdayTypicalSteps: Map<kotlinx.datetime.DayOfWeek, Int> = emptyMap(),
 )

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/services/HealthStatsSync.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/services/HealthStatsSync.kt
@@ -194,7 +194,41 @@ internal fun buildWeekdayTypicalsFromData(
     timeZone: TimeZone,
 ): Map<DayOfWeek, ByteArray> {
     if (allData.isEmpty()) return emptyMap()
-    return emptyMap()
+
+    val slotSteps = Array(7) { LongArray(TYPICAL_STEP_BINS) }
+    val slotDays = Array(7) { Array(TYPICAL_STEP_BINS) { mutableSetOf<Long>() } }
+    val matchingDays = Array(7) { mutableSetOf<Long>() }
+
+    for (entry in allData) {
+        val entryDate = kotlinx.datetime.Instant.fromEpochSeconds(entry.timestamp)
+            .toLocalDateTime(timeZone).date
+        val wd = entryDate.dayOfWeek.ordinal
+        val dayStart = entryDate.atStartOfDayIn(timeZone).epochSeconds
+        val slot = ((entry.timestamp - dayStart) / TYPICAL_STEP_BIN_SECONDS)
+            .toInt()
+            .coerceIn(0, TYPICAL_STEP_BINS - 1)
+        slotSteps[wd][slot] += entry.steps.toLong()
+        slotDays[wd][slot].add(dayStart)
+        matchingDays[wd].add(dayStart)
+    }
+
+    val result = mutableMapOf<DayOfWeek, ByteArray>()
+    for (wd in 0..6) {
+        if (matchingDays[wd].size < MIN_DAYS_FOR_TYPICAL) continue
+        val buffer = DataBuffer(TYPICAL_STEP_BINS * UShort.SIZE_BYTES)
+            .apply { setEndian(Endian.Little) }
+        for (slot in 0 until TYPICAL_STEP_BINS) {
+            val count = slotDays[wd][slot].size
+            val value: UShort = if (count == 0) {
+                UNKNOWN_TYPICAL_STEPS
+            } else {
+                (slotSteps[wd][slot] / count).coerceIn(0L, 0xFFFEL).toInt().toUShort()
+            }
+            buffer.putUShort(value)
+        }
+        result[DayOfWeek.entries[wd]] = buffer.array().toByteArray()
+    }
+    return result
 }
 
 // Extension functions

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/services/HealthStatsSync.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/services/HealthStatsSync.kt
@@ -232,3 +232,19 @@ private val SLEEP_KEYS =
         DayOfWeek.SATURDAY to "saturday_sleepData",
         DayOfWeek.SUNDAY to "sunday_sleepData",
     )
+
+private const val TYPICAL_STEP_BINS = 96
+private const val TYPICAL_STEP_BIN_SECONDS = 900L
+private const val TYPICAL_STEP_HISTORY_WEEKS = 7
+private const val MIN_DAYS_FOR_TYPICAL = 2
+private const val UNKNOWN_TYPICAL_STEPS: UShort = 0xFFFFu
+
+private val STEP_TYPICAL_KEYS = mapOf(
+    DayOfWeek.MONDAY to "monday_steps",
+    DayOfWeek.TUESDAY to "tuesday_steps",
+    DayOfWeek.WEDNESDAY to "wednesday_steps",
+    DayOfWeek.THURSDAY to "thursday_steps",
+    DayOfWeek.FRIDAY to "friday_steps",
+    DayOfWeek.SATURDAY to "saturday_steps",
+    DayOfWeek.SUNDAY to "sunday_steps",
+)

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/services/HealthStatsSync.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/services/HealthStatsSync.kt
@@ -21,6 +21,7 @@ import co.touchlab.kermit.Logger
 import io.rebble.libpebblecommon.database.dao.DailyMovementAggregate
 import io.rebble.libpebblecommon.database.dao.HealthAggregates
 import io.rebble.libpebblecommon.database.dao.HealthDao
+import io.rebble.libpebblecommon.database.entity.HealthDataEntity
 import io.rebble.libpebblecommon.database.entity.HealthStat
 import io.rebble.libpebblecommon.database.entity.HealthStatDao
 import io.rebble.libpebblecommon.util.DataBuffer
@@ -32,6 +33,7 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.atStartOfDayIn
 import kotlinx.datetime.minus
 import kotlinx.datetime.plus
+import kotlinx.datetime.toLocalDateTime
 
 private val logger = Logger.withTag("HealthStatsSync")
 
@@ -176,6 +178,23 @@ private fun movementPayload(dayStartEpochSec: Long, aggregates: HealthAggregates
     }
 
     return buffer.array()
+}
+
+/**
+ * Bins a flat list of HealthDataEntity rows into per-weekday 15-minute typical-step payloads.
+ *
+ * For each weekday with at least MIN_DAYS_FOR_TYPICAL distinct matching days in the input,
+ * emits a 192-byte little-endian payload of 96 UShort values. A slot's value is the average
+ * step count across the distinct matching days that had at least one row overlapping that
+ * slot; if zero matching days covered the slot, the value is UNKNOWN_TYPICAL_STEPS so the
+ * watch sum-skips it. Weekdays below the threshold are omitted from the result.
+ */
+internal fun buildWeekdayTypicalsFromData(
+    allData: List<HealthDataEntity>,
+    timeZone: TimeZone,
+): Map<DayOfWeek, ByteArray> {
+    if (allData.isEmpty()) return emptyMap()
+    return emptyMap()
 }
 
 // Extension functions

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/services/HealthStatsSync.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/services/HealthStatsSync.kt
@@ -247,6 +247,29 @@ internal fun buildWeekdayTypicalsFromData(
  * Returns one entry per weekday that has at least [MIN_DAYS_FOR_TYPICAL] distinct matching days
  * in the queried window. Empty map when there's no data or no weekday clears the threshold.
  */
+/**
+ * Sums the 96 little-endian UShort step counts in a typical-step payload, skipping the
+ * UNKNOWN sentinel — i.e., "total typical steps for the day represented by this payload."
+ *
+ * Used by the debug stats dialog to surface the per-weekday typical totals; mirrors the
+ * watch firmware's [`prv_cur_step_avg`](activity_insights.c:1143) which sums the same
+ * array.
+ */
+internal fun decodeTypicalStepTotal(payload: ByteArray): Int {
+    require(payload.size == TYPICAL_STEP_BINS * UShort.SIZE_BYTES) {
+        "typical-step payload must be ${TYPICAL_STEP_BINS * UShort.SIZE_BYTES} bytes, got ${payload.size}"
+    }
+    var total = 0
+    for (slot in 0 until TYPICAL_STEP_BINS) {
+        val byteOffset = slot * 2
+        val lo = payload[byteOffset].toInt() and 0xFF
+        val hi = payload[byteOffset + 1].toInt() and 0xFF
+        val v = (hi shl 8) or lo
+        if (v != UNKNOWN_TYPICAL_STEPS.toInt()) total += v
+    }
+    return total
+}
+
 internal suspend fun computeAllWeekdayTypicalSteps(
     healthDao: HealthDao,
     today: LocalDate,

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/services/HealthStatsSync.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/services/HealthStatsSync.kt
@@ -117,6 +117,15 @@ internal suspend fun updateHealthStatsInDatabase(
         ))
     }
 
+    // Per-weekday typical-step blobs (consumed by firmware activity_insights for the
+    // "X% above/below typical" comparison in the end-of-day activity summary notification).
+    val typicalsByWeekday = computeAllWeekdayTypicalSteps(healthDao, today, timeZone)
+    for ((dayOfWeek, payload) in typicalsByWeekday) {
+        val key = STEP_TYPICAL_KEYS.getValue(dayOfWeek)
+        stats.add(HealthStat(key = key, payload = payload))
+    }
+    logger.d { "HEALTH_STATS: Wrote ${typicalsByWeekday.size} weekday typical-step rows" }
+
     // Batch insert all stats
     healthStatDao.insertOrReplace(stats)
     logger.d { "HEALTH_STATS: Updated ${stats.size} stats in database for automatic syncing" }
@@ -229,6 +238,27 @@ internal fun buildWeekdayTypicalsFromData(
         result[DayOfWeek.entries[wd]] = buffer.array().toByteArray()
     }
     return result
+}
+
+/**
+ * Queries the last [TYPICAL_STEP_HISTORY_WEEKS] weeks of HealthDataEntity rows (excluding today)
+ * and bins them into per-weekday 15-min typical-step payloads via [buildWeekdayTypicalsFromData].
+ *
+ * Returns one entry per weekday that has at least [MIN_DAYS_FOR_TYPICAL] distinct matching days
+ * in the queried window. Empty map when there's no data or no weekday clears the threshold.
+ */
+internal suspend fun computeAllWeekdayTypicalSteps(
+    healthDao: HealthDao,
+    today: LocalDate,
+    timeZone: TimeZone,
+): Map<DayOfWeek, ByteArray> {
+    val rangeEnd = today.atStartOfDayIn(timeZone).epochSeconds
+    val rangeStart = today
+        .minus(DatePeriod(days = TYPICAL_STEP_HISTORY_WEEKS * 7))
+        .atStartOfDayIn(timeZone)
+        .epochSeconds
+    val allData = healthDao.getHealthDataForRange(rangeStart, rangeEnd)
+    return buildWeekdayTypicalsFromData(allData, timeZone)
 }
 
 // Extension functions

--- a/libpebble3/src/commonTest/kotlin/io/rebble/libpebblecommon/services/HealthStatsSyncTest.kt
+++ b/libpebble3/src/commonTest/kotlin/io/rebble/libpebblecommon/services/HealthStatsSyncTest.kt
@@ -1,0 +1,26 @@
+package io.rebble.libpebblecommon.services
+
+import io.rebble.libpebblecommon.database.entity.HealthDataEntity
+import kotlinx.datetime.TimeZone
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class HealthStatsSyncTest {
+    @Test
+    fun buildWeekdayTypicalsFromData_emptyInput_returnsEmptyMap() {
+        val result = buildWeekdayTypicalsFromData(emptyList(), TimeZone.UTC)
+        assertTrue(result.isEmpty(), "empty input should produce empty map, got keys=${result.keys}")
+    }
+}
+
+private fun row(timestamp: Long, steps: Int) = HealthDataEntity(
+    timestamp = timestamp,
+    steps = steps,
+    orientation = 0,
+    intensity = 0,
+    lightIntensity = 0,
+    activeMinutes = 0,
+    restingGramCalories = 0,
+    activeGramCalories = 0,
+    distanceCm = 0,
+)

--- a/libpebble3/src/commonTest/kotlin/io/rebble/libpebblecommon/services/HealthStatsSyncTest.kt
+++ b/libpebble3/src/commonTest/kotlin/io/rebble/libpebblecommon/services/HealthStatsSyncTest.kt
@@ -1,8 +1,16 @@
 package io.rebble.libpebblecommon.services
 
 import io.rebble.libpebblecommon.database.entity.HealthDataEntity
+import kotlinx.datetime.DatePeriod
+import kotlinx.datetime.DayOfWeek
+import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
+import kotlinx.datetime.atStartOfDayIn
+import kotlinx.datetime.plus
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class HealthStatsSyncTest {
@@ -10,6 +18,95 @@ class HealthStatsSyncTest {
     fun buildWeekdayTypicalsFromData_emptyInput_returnsEmptyMap() {
         val result = buildWeekdayTypicalsFromData(emptyList(), TimeZone.UTC)
         assertTrue(result.isEmpty(), "empty input should produce empty map, got keys=${result.keys}")
+    }
+
+    @Test
+    fun buildWeekdayTypicalsFromData_singleMatchingDay_skipsWeekday() {
+        // 2026-01-05 is a Monday. Provide rows for only that one Monday;
+        // MIN_DAYS_FOR_TYPICAL = 2, so Monday must be absent from the result.
+        val mondayStart = LocalDate(2026, 1, 5).atStartOfDayIn(TimeZone.UTC).epochSeconds
+        val rows = (0..23).map { hour ->
+            row(timestamp = mondayStart + hour * 3600L, steps = 100)
+        }
+
+        val result = buildWeekdayTypicalsFromData(rows, TimeZone.UTC)
+
+        assertFalse(
+            result.containsKey(DayOfWeek.MONDAY),
+            "Monday should be absent with only 1 matching day, got keys=${result.keys}",
+        )
+    }
+
+    @Test
+    fun buildWeekdayTypicalsFromData_twoMondays_producesPayload() {
+        // Two Mondays meet MIN_DAYS_FOR_TYPICAL=2. Each Monday has one row in slot 32
+        // (08:00-08:15) with 200 steps. Expected: result has MONDAY, slot 32 = 200.
+        val mon1 = LocalDate(2026, 1, 5).atStartOfDayIn(TimeZone.UTC).epochSeconds
+        val mon2 = LocalDate(2026, 1, 12).atStartOfDayIn(TimeZone.UTC).epochSeconds
+        val slot32Offset = 32 * 900L
+
+        val rows = listOf(
+            row(timestamp = mon1 + slot32Offset, steps = 200),
+            row(timestamp = mon2 + slot32Offset, steps = 200),
+        )
+
+        val result = buildWeekdayTypicalsFromData(rows, TimeZone.UTC)
+
+        val payload = result[DayOfWeek.MONDAY]
+        assertNotNull(payload, "Monday payload missing; got keys=${result.keys}")
+        assertEquals(192, payload.size, "payload should be 96 * 2 = 192 bytes")
+        assertEquals(200, readUShortLE(payload, 32), "slot 32 should be 200")
+    }
+
+    @Test
+    fun buildWeekdayTypicalsFromData_slotWithNoData_writesSentinel() {
+        // Two Mondays each with a row in slot 32. Slot 0 has no data on either Monday.
+        // Expected: slot 0 = 0xFFFF (sentinel).
+        val mon1 = LocalDate(2026, 1, 5).atStartOfDayIn(TimeZone.UTC).epochSeconds
+        val mon2 = LocalDate(2026, 1, 12).atStartOfDayIn(TimeZone.UTC).epochSeconds
+        val slot32Offset = 32 * 900L
+
+        val rows = listOf(
+            row(timestamp = mon1 + slot32Offset, steps = 200),
+            row(timestamp = mon2 + slot32Offset, steps = 200),
+        )
+
+        val payload = buildWeekdayTypicalsFromData(rows, TimeZone.UTC)[DayOfWeek.MONDAY]
+        assertNotNull(payload)
+        assertEquals(0xFFFF, readUShortLE(payload, 0), "slot 0 must be UNKNOWN sentinel")
+        assertEquals(0xFFFF, readUShortLE(payload, 95), "slot 95 must be UNKNOWN sentinel")
+    }
+
+    @Test
+    fun buildWeekdayTypicalsFromData_partialSlotCoverage_avgIsPerSlotNotPerDay() {
+        // Five Mondays: each contributes 100 steps in slot 60. Two more Mondays exist
+        // (with rows in OTHER slots) so they count toward matchingDays but NOT toward
+        // slot 60's per-slot day count. Expected slot 60 = 100 (sum=500, slot-day-count=5),
+        // NOT 71 (sum=500, total-matching-days=7).
+        val mondays = (0..6).map { week ->
+            LocalDate(2026, 1, 5).plus(DatePeriod(days = 7 * week)).atStartOfDayIn(TimeZone.UTC).epochSeconds
+        }
+        val slot60Offset = 60 * 900L
+        val slot10Offset = 10 * 900L
+
+        val rows = buildList {
+            // First 5 Mondays: rows in slot 60 with 100 steps
+            for (i in 0..4) add(row(timestamp = mondays[i] + slot60Offset, steps = 100))
+            // Last 2 Mondays: rows in slot 10 only (count toward matchingDays, not slot-60-day-count)
+            for (i in 5..6) add(row(timestamp = mondays[i] + slot10Offset, steps = 50))
+        }
+
+        val payload = buildWeekdayTypicalsFromData(rows, TimeZone.UTC)[DayOfWeek.MONDAY]
+        assertNotNull(payload)
+        assertEquals(100, readUShortLE(payload, 60), "slot 60 must average over per-slot days (5), not total matching days (7)")
+    }
+
+    /** Reads a single little-endian UShort at byte offset slotIndex * 2 from payload. Returns Int 0..65535. */
+    private fun readUShortLE(payload: ByteArray, slotIndex: Int): Int {
+        val byteOffset = slotIndex * 2
+        val lo = payload[byteOffset].toInt() and 0xFF
+        val hi = payload[byteOffset + 1].toInt() and 0xFF
+        return (hi shl 8) or lo
     }
 }
 

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/HealthStatsDialog.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/HealthStatsDialog.kt
@@ -35,6 +35,7 @@ import io.rebble.libpebblecommon.connection.LibPebble
 import io.rebble.libpebblecommon.health.HealthDebugStats
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.datetime.DayOfWeek
 import kotlin.time.Duration.Companion.seconds
 
 private val logger = Logger.withTag("HealthStatsDialog")
@@ -170,6 +171,35 @@ fun HealthStatsDialog(libPebble: LibPebble, onDismissRequest: () -> Unit) {
                                 style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                             )
+                        }
+
+                        Spacer(Modifier.height(4.dp))
+
+                        Text(
+                            "Typical steps by weekday",
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
+                        for (wd in DayOfWeek.entries) {
+                            val total = s.weekdayTypicalSteps[wd]
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.SpaceBetween
+                            ) {
+                                Text(
+                                    wd.name.lowercase().replaceFirstChar { it.uppercase() },
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                                Text(
+                                    total?.toString() ?: "--",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = if (total != null) {
+                                        MaterialTheme.colorScheme.onSurface
+                                    } else {
+                                        MaterialTheme.colorScheme.onSurfaceVariant
+                                    },
+                                )
+                            }
                         }
                     }
                 } else {

--- a/pebble/src/iosMain/kotlin/coredevices/pebble/actions/watch/HealthStats.kt
+++ b/pebble/src/iosMain/kotlin/coredevices/pebble/actions/watch/HealthStats.kt
@@ -8,5 +8,7 @@ import io.rebble.libpebblecommon.health.HealthDebugStats
 fun healthDebugStatsToJson(stats: HealthDebugStats): String {
     val lastNight = stats.lastNightSleepHours?.toString() ?: "null"
     val latestTs = stats.latestDataTimestamp?.toString() ?: "null"
-    return """{"totalSteps30Days":${stats.totalSteps30Days},"averageStepsPerDay":${stats.averageStepsPerDay},"totalSleepSeconds30Days":${stats.totalSleepSeconds30Days},"averageSleepSecondsPerDay":${stats.averageSleepSecondsPerDay},"todaySteps":${stats.todaySteps},"lastNightSleepHours":$lastNight,"latestDataTimestamp":$latestTs,"daysOfData":${stats.daysOfData}}"""
+    val typicalSteps = stats.weekdayTypicalSteps.entries
+        .joinToString(prefix = "{", postfix = "}") { (wd, total) -> "\"$wd\":$total" }
+    return """{"totalSteps30Days":${stats.totalSteps30Days},"averageStepsPerDay":${stats.averageStepsPerDay},"totalSleepSeconds30Days":${stats.totalSleepSeconds30Days},"averageSleepSecondsPerDay":${stats.averageSleepSecondsPerDay},"todaySteps":${stats.todaySteps},"lastNightSleepHours":$lastNight,"latestDataTimestamp":$latestTs,"daysOfData":${stats.daysOfData},"weekdayTypicalSteps":$typicalSteps}"""
 }


### PR DESCRIPTION
See https://github.com/coredevices/mobileapp/issues/78

should fix step insights at the end of the day not showing typical values, plus the typical <day> number under health app.

<img width="200" height="228" alt="image" src="https://github.com/user-attachments/assets/ce2ef1a5-03a5-4d58-ba29-d7798f7cb786" />

doesn't have the typical sleep one yet, that's at #194 