### PR TITLE
libpebble3: add calendar reminder vibration override

### DIFF
--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/LibPebbleConfig.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/LibPebbleConfig.kt
@@ -144,6 +144,7 @@ data class NotificationConfig(
      * Shown under "Canned messages" in the watch action menu.
      */
     val cannedResponses: List<String> = listOf("Ok", "Yes", "No", "Call me", "Call you later"),
+    val overrideCalendarVibePattern: String? = null,
 )
 
 class NotificationConfigFlow(val flow: StateFlow<LibPebbleConfig>) {

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/calendar/CalendarEvent.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/calendar/CalendarEvent.kt
@@ -54,7 +54,7 @@ private fun transformDescription(rawDescription: String): String {
     return rawDescription.replace(regex, "").trimWithEllipsis(300)
 }
 
-fun CalendarEvent.toTimelineReminder(timestamp: Instant, pinUuid: Uuid): TimelineReminder =
+fun CalendarEvent.toTimelineReminder(timestamp: Instant, pinUuid: Uuid, vibePattern: List<UInt>? = null): TimelineReminder =
     buildTimelineReminder(
         parentId = pinUuid,
         timestamp = timestamp,
@@ -65,6 +65,7 @@ fun CalendarEvent.toTimelineReminder(timestamp: Instant, pinUuid: Uuid): Timelin
                 location { location }
             }
             tinyIcon { TimelineIcon.NotificationReminder }
+            vibePattern?.let { vibrationPattern { it } }
             // TODO attendees
         }
         flags {
@@ -100,6 +101,7 @@ private object DefaultTitles {
 fun CalendarEvent.toTimelinePin(
     calendar: CalendarEntity,
     supportsRsvpActions: Boolean,
+    vibePattern: List<UInt>? = null,
 ): TimelinePin = buildTimelinePin(
     parentId = CALENDAR_APP_UUID,
     timestamp = startTime,
@@ -161,6 +163,7 @@ fun CalendarEvent.toTimelinePin(
 //        }
         stringList(TimelineAttribute.Headings) { headings }
         stringList(TimelineAttribute.Paragraphs) { paragraphs }
+        vibePattern?.let { vibrationPattern { it } }
     }
     actions {
         if (supportsRsvpActions) {

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/calendar/PhoneCalendarSyncer.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/calendar/PhoneCalendarSyncer.kt
@@ -1,6 +1,7 @@
 package io.rebble.libpebblecommon.calendar
 
 import co.touchlab.kermit.Logger
+import io.rebble.libpebblecommon.NotificationConfigFlow
 import io.rebble.libpebblecommon.SystemAppIDs.CALENDAR_APP_UUID
 import io.rebble.libpebblecommon.WatchConfigFlow
 import io.rebble.libpebblecommon.connection.Calendar
@@ -8,6 +9,7 @@ import io.rebble.libpebblecommon.connection.endpointmanager.blobdb.TimeProvider
 import io.rebble.libpebblecommon.database.dao.CalendarDao
 import io.rebble.libpebblecommon.database.dao.TimelinePinRealDao
 import io.rebble.libpebblecommon.database.dao.TimelineReminderRealDao
+import io.rebble.libpebblecommon.database.dao.VibePatternDao
 import io.rebble.libpebblecommon.database.entity.CalendarEntity
 import io.rebble.libpebblecommon.database.entity.TimelinePin
 import io.rebble.libpebblecommon.database.entity.TimelineReminder
@@ -16,6 +18,9 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.conflate
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.sample
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
@@ -33,6 +38,8 @@ class PhoneCalendarSyncer(
     private val libPebbleCoroutineScope: LibPebbleCoroutineScope,
     private val timelineReminderDao: TimelineReminderRealDao,
     private val watchConfig: WatchConfigFlow,
+    private val notificationConfigFlow: NotificationConfigFlow,
+    private val vibePatternDao: VibePatternDao,
 ) : Calendar {
     private val logger = Logger.withTag("PhoneCalendarSyncer")
     private val syncTrigger = MutableSharedFlow<Unit>()
@@ -66,6 +73,13 @@ class PhoneCalendarSyncer(
                         previousShowDeclinedEvents = it.watchConfig.calendarShowDeclinedEvents
                     }
                 }
+            }
+            libPebbleCoroutineScope.launch {
+                notificationConfigFlow.flow
+                    .map { it.notificationConfig.overrideCalendarVibePattern }
+                    .distinctUntilChanged()
+                    .drop(1)
+                    .collect { requestSync() }
             }
         }
     }
@@ -129,6 +143,8 @@ class PhoneCalendarSyncer(
         val existingPins = timelinePinDao.getPinsForWatchapp(CALENDAR_APP_UUID)
         val startDate = timeProvider.now() - 1.days
         val endDate = (startDate + 7.days)
+        val calendarVibePattern = notificationConfigFlow.value.overrideCalendarVibePattern
+            ?.let { vibePatternDao.getVibePattern(it)?.pattern }
         val newPins = allCalendars.flatMap { calendar ->
             if (!calendar.enabled || !pinsEnabled) {
                 return@flatMap emptyList()
@@ -141,7 +157,7 @@ class PhoneCalendarSyncer(
                 }
             val supportsRsvp = systemCalendar.supportsPinActions()
             events.map { event ->
-                EventAndPin(event, event.toTimelinePin(calendar, supportsRsvp))
+                EventAndPin(event, event.toTimelinePin(calendar, supportsRsvp, calendarVibePattern))
             }
         }
         val remindersToInsert = mutableListOf<TimelineReminder>()
@@ -153,6 +169,7 @@ class PhoneCalendarSyncer(
                 remindersEnabled = remindersEnabled,
                 event = new.event,
                 pinId = existingPin?.itemId ?: newPin.itemId,
+                vibePattern = calendarVibePattern,
                 remindersToInsert = remindersToInsert,
                 remindersToDelete = remindersToDelete,
             )
@@ -197,6 +214,7 @@ class PhoneCalendarSyncer(
         remindersEnabled: Boolean,
         event: CalendarEvent,
         pinId: Uuid,
+        vibePattern: List<UInt>?,
         remindersToInsert: MutableList<TimelineReminder>,
         remindersToDelete: MutableList<Uuid>,
     ) {
@@ -211,12 +229,15 @@ class PhoneCalendarSyncer(
             }
         }.map { it.itemId }
 
-        remindersToInsert += eventReminderTimestamps.filter { t ->
-            if (!remindersEnabled) return@filter false
-            existingReminders.none { er ->
-                er.content.timestamp.instant == t
+        remindersToInsert += eventReminderTimestamps.mapNotNull { t ->
+            if (!remindersEnabled) return@mapNotNull null
+            val newReminder = event.toTimelineReminder(t, pinId, vibePattern)
+            val existing = existingReminders.find { er -> er.content.timestamp.instant == t }
+            if (existing != null && existing.recordHashCode() == newReminder.recordHashCode()) {
+                return@mapNotNull null
             }
-        }.map { event.toTimelineReminder(it, pinId) }
+            newReminder.copy(itemId = existing?.itemId ?: newReminder.itemId)
+        }
     }
 
     override fun calendars(): Flow<List<CalendarEntity>> = calendarDao.getFlow()


### PR DESCRIPTION
## Summary

Adds `NotificationConfig.overrideCalendarVibePattern: String?` to mirror the existing `overrideDefaultVibePattern` (which covers notifications). When set, the named pattern is applied to every calendar reminder synced to the watch.

Also adds an optional `vibePattern: List<UInt>?` parameter to:

- `CalendarEvent.toTimelineReminder(timestamp, pinUuid, vibePattern = null)`
- `CalendarEvent.toTimelinePin(calendar, supportsRsvpActions, vibePattern = null)`

Both default to `null` — existing callers are unaffected.

## Motivation

The notification path already supports a global vibration-pattern override via `overrideDefaultVibePattern`. Calendar reminders are the other major surface where a user might want to enforce a specific vibration style without per-app or per-event configuration. The symmetric `overrideCalendarVibePattern` field closes that gap.

`PhoneCalendarSyncer` is the only producer of calendar `TimelinePin` and `TimelineReminder` items in libpebble3, so the wiring is contained.

## Implementation

Three files change:

- `LibPebbleConfig.kt` — adds one `String?` field to `NotificationConfig`.
- `CalendarEvent.kt` — `toTimelineReminder` and `toTimelinePin` both gain an optional `vibePattern: List<UInt>?` parameter. When non-null, the reminder / pin's attribute block appends `vibrationPattern { it }`.
- `PhoneCalendarSyncer.kt` — resolves the name in `overrideCalendarVibePattern` to the actual pattern bytes via `VibePatternDao` and passes them to both builders during sync. Also re-triggers a full calendar sync whenever the config changes, via a `notificationConfigFlow.flow` collector with `.distinctUntilChanged().drop(1)`, so an in-flight override change immediately rewrites the existing pins on the watch instead of waiting for the next event modification.

## Behavior notes

The watch fires the actual vibration from the `TimelineReminder`, not the `TimelinePin` — but the pattern is set on both for consistency (the pin's attribute is harmless when unused).

## Backward compatibility

Non-breaking. New field and params all default to `null`; callers that don't set `overrideCalendarVibePattern` or pass `vibePattern` see no behavior change.

## Test plan

- [x] Set `overrideCalendarVibePattern` to a known pattern name → next calendar reminder on the watch fires with that pattern
- [x] Unset the override → next reminder reverts to the bundled default
- [x] Change the override mid-day → existing pins on the watch get rewritten (validates the reactive re-sync collector)
- [x] Leave the override null → behavior identical to before this change
