### PR TITLE
Convert ms timeouts to seconds in UI

### DIFF
--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchPrefsScreen.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchPrefsScreen.kt
@@ -135,22 +135,67 @@ fun WatchPref<*>.section(): Section = when (this) {
 
 private fun numberPref(item: WatchPreference<Long>, libPebble: LibPebble): SettingsItem {
     val pref = item.pref as NumberWatchPref
-    return basicSettingsNumberItem(
-        id = pref.id,
-        title = pref.displayName,
-        description = pref.description,
-        topLevelType = TopLevelType.Watch,
-        section = pref.section(),
-        value = item.valueOrDefault(),
-        min = pref.min,
-        max = pref.max,
-        onValueChange = {
-            libPebble.setWatchPref(item.copy(value = it))
-        },
-        isDebugSetting = pref.isDebugSetting,
-        defaultValue = pref.defaultValue,
-        unit = pref.unit,
-    )
+    return when (pref) {
+        NumberWatchPref.BacklightTimeoutMs -> {
+            val secValue = item.valueOrDefault() / 1000
+            basicSettingsNumberItem(
+                id = pref.id,
+                title = pref.displayName,
+                description = pref.description,
+                topLevelType = TopLevelType.Watch,
+                section = pref.section(),
+                value = secValue,
+                min = 1,
+                max = 10,
+                onValueChange = {
+                    libPebble.setWatchPref(item.copy(value = it * 1000))
+                },
+                isDebugSetting = pref.isDebugSetting,
+                defaultValue = pref.defaultValue / 1000,
+                unit = "seconds",
+                valueFormatter = { "$it seconds" },
+            )
+        }
+        NumberWatchPref.NotificationTimeoutMs -> {
+            val secValue = item.valueOrDefault() / 1000
+            basicSettingsNumberItem(
+                id = pref.id,
+                title = pref.displayName,
+                description = pref.description,
+                topLevelType = TopLevelType.Watch,
+                section = pref.section(),
+                value = secValue,
+                min = 0,
+                max = 600,
+                onValueChange = {
+                    libPebble.setWatchPref(item.copy(value = it * 1000))
+                },
+                isDebugSetting = pref.isDebugSetting,
+                defaultValue = pref.defaultValue / 1000,
+                unit = "",
+                valueFormatter = { v ->
+                    "${v / 60}:${(v % 60).toString().padStart(2, '0')}"
+                },
+                stepsOverride = 19,
+            )
+        }
+        else -> basicSettingsNumberItem(
+            id = pref.id,
+            title = pref.displayName,
+            description = pref.description,
+            topLevelType = TopLevelType.Watch,
+            section = pref.section(),
+            value = item.valueOrDefault(),
+            min = pref.min,
+            max = pref.max,
+            onValueChange = {
+                libPebble.setWatchPref(item.copy(value = it))
+            },
+            isDebugSetting = pref.isDebugSetting,
+            defaultValue = pref.defaultValue,
+            unit = pref.unit,
+        )
+    }
 }
 
 private fun colorPref(item: WatchPreference<TimelineColor>, libPebble: LibPebble): SettingsItem {

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchPrefsScreen.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchPrefsScreen.kt
@@ -16,6 +16,8 @@ import androidx.compose.ui.unit.sp
 import coredevices.pebble.rememberLibPebble
 import coredevices.ui.ConfirmDialog
 import io.rebble.libpebblecommon.SystemAppIDs.AIRPLANE_MODE_UUID
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 import io.rebble.libpebblecommon.SystemAppIDs.BACKLIGHT_UUID
 import io.rebble.libpebblecommon.SystemAppIDs.HEALTH_APP_UUID
 import io.rebble.libpebblecommon.SystemAppIDs.MOTION_BACKLIGHT_UUID
@@ -37,6 +39,10 @@ import io.rebble.libpebblecommon.locker.AppType
 import io.rebble.libpebblecommon.timeline.TimelineColor
 import kotlinx.coroutines.flow.map
 import kotlin.uuid.Uuid
+
+// Snap the notification timeout slider to 30-second increments (20 stops across 0..600s)
+// so the displayed MM:SS value is always a clean :00 or :30.
+private const val NOTIFICATION_TIMEOUT_STEP_COUNT = 19
 
 @Composable
 fun watchPrefs(): List<SettingsItem> {
@@ -137,46 +143,22 @@ private fun numberPref(item: WatchPreference<Long>, libPebble: LibPebble): Setti
     val pref = item.pref as NumberWatchPref
     return when (pref) {
         NumberWatchPref.BacklightTimeoutMs -> {
-            val secValue = item.valueOrDefault() / 1000
-            basicSettingsNumberItem(
-                id = pref.id,
-                title = pref.displayName,
-                description = pref.description,
-                topLevelType = TopLevelType.Watch,
-                section = pref.section(),
-                value = secValue,
-                min = 1,
-                max = 10,
-                onValueChange = {
-                    libPebble.setWatchPref(item.copy(value = it * 1000))
-                },
-                isDebugSetting = pref.isDebugSetting,
-                defaultValue = pref.defaultValue / 1000,
-                unit = "seconds",
-                valueFormatter = { "$it seconds" },
+            basicSettingsNumberSecondsItem(
+                pref = pref,
+                item = item,
+                libPebble = libPebble,
+                valueFormatter = { seconds -> "$seconds seconds" },
             )
         }
         NumberWatchPref.NotificationTimeoutMs -> {
-            val secValue = item.valueOrDefault() / 1000
-            basicSettingsNumberItem(
-                id = pref.id,
-                title = pref.displayName,
-                description = pref.description,
-                topLevelType = TopLevelType.Watch,
-                section = pref.section(),
-                value = secValue,
-                min = 0,
-                max = 600,
-                onValueChange = {
-                    libPebble.setWatchPref(item.copy(value = it * 1000))
+            basicSettingsNumberSecondsItem(
+                pref = pref,
+                item = item,
+                libPebble = libPebble,
+                valueFormatter = { seconds ->
+                    "${seconds / 60}:${(seconds % 60).toString().padStart(2, '0')}"
                 },
-                isDebugSetting = pref.isDebugSetting,
-                defaultValue = pref.defaultValue / 1000,
-                unit = "",
-                valueFormatter = { v ->
-                    "${v / 60}:${(v % 60).toString().padStart(2, '0')}"
-                },
-                stepsOverride = 19,
+                steps = NOTIFICATION_TIMEOUT_STEP_COUNT,
             )
         }
         else -> basicSettingsNumberItem(
@@ -197,6 +179,31 @@ private fun numberPref(item: WatchPreference<Long>, libPebble: LibPebble): Setti
         )
     }
 }
+
+private fun basicSettingsNumberSecondsItem(
+    pref: NumberWatchPref,
+    item: WatchPreference<Long>,
+    libPebble: LibPebble,
+    valueFormatter: (Long) -> String,
+    steps: Int? = null,
+): SettingsItem = basicSettingsNumberItem(
+    id = pref.id,
+    title = pref.displayName,
+    description = pref.description,
+    topLevelType = TopLevelType.Watch,
+    section = pref.section(),
+    value = item.valueOrDefault().milliseconds.inWholeSeconds,
+    min = pref.min.milliseconds.inWholeSeconds.toInt(),
+    max = pref.max.milliseconds.inWholeSeconds.toInt(),
+    onValueChange = {
+        libPebble.setWatchPref(item.copy(value = it.seconds.inWholeMilliseconds))
+    },
+    isDebugSetting = pref.isDebugSetting,
+    defaultValue = pref.defaultValue.milliseconds.inWholeSeconds,
+    unit = "",
+    valueFormatter = valueFormatter,
+    steps = steps,
+)
 
 private fun colorPref(item: WatchPreference<TimelineColor>, libPebble: LibPebble): SettingsItem {
     val pref = item.pref as ColorWatchPref

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchSettingsScreen.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchSettingsScreen.kt
@@ -2121,6 +2121,7 @@ fun basicSettingsNumberItem(
     isDebugSetting: Boolean = false,
     defaultValue: Long? = null,
     valueFormatter: ((Long) -> String)? = null,
+    stepsOverride: Int? = null,
 ) = SettingsItem(
     id = id,
     title = title,
@@ -2142,9 +2143,8 @@ fun basicSettingsNumberItem(
                     }
                     val minF = remember(min) { min.toFloat() }
                     val maxF = remember(max) { max.toFloat() }
-                    val steps = remember(max, min) {
+                    val steps = stepsOverride ?: remember(max, min) {
                         val range = max - min
-                        // Too many steps ANRs the app
                         if (range in 1..100) range - 1 else 0
                     }
                     Slider(
@@ -2171,7 +2171,7 @@ fun basicSettingsNumberItem(
                                 enabled = value != defaultValue,
                             ) {
                                 Text(
-                                    text = "Default: $defaultValue",
+                                    text = "Default: ${valueFormatter?.invoke(defaultValue) ?: "$defaultValue $unit"}",
                                     modifier = Modifier.widthIn(max = 150.dp),
                                     maxLines = 1,
                                     lineHeight = 12.sp,

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchSettingsScreen.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchSettingsScreen.kt
@@ -2121,7 +2121,7 @@ fun basicSettingsNumberItem(
     isDebugSetting: Boolean = false,
     defaultValue: Long? = null,
     valueFormatter: ((Long) -> String)? = null,
-    stepsOverride: Int? = null,
+    steps: Int? = null,
 ) = SettingsItem(
     id = id,
     title = title,
@@ -2143,7 +2143,7 @@ fun basicSettingsNumberItem(
                     }
                     val minF = remember(min) { min.toFloat() }
                     val maxF = remember(max) { max.toFloat() }
-                    val steps = stepsOverride ?: remember(max, min) {
+                    val steps = steps ?: remember(max, min) {
                         val range = max - min
                         if (range in 1..100) range - 1 else 0
                     }

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchSettingsScreen.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchSettingsScreen.kt
@@ -2143,7 +2143,7 @@ fun basicSettingsNumberItem(
                     }
                     val minF = remember(min) { min.toFloat() }
                     val maxF = remember(max) { max.toFloat() }
-                    val steps = steps ?: remember(max, min) {
+                    val resolvedSteps = steps ?: remember(max, min) {
                         val range = max - min
                         if (range in 1..100) range - 1 else 0
                     }
@@ -2151,7 +2151,7 @@ fun basicSettingsNumberItem(
                         value = sliderPosition.toFloat(),
                         onValueChange = { sliderPosition = it.roundToLong() },
                         valueRange = minF..maxF,
-                        steps = steps,
+                        steps = resolvedSteps,
                         onValueChangeFinished = {
                             onValueChange(sliderPosition)
                         },


### PR DESCRIPTION
Display BacklightTimeoutMs and NotificationTimeoutMs as seconds and minutes:seconds respectively. Adjusts slider steps and formats default values to match the new units.