### PR TITLE
libpebble3: Compose-free public API (PebbleBitmap), extract Contacts, relocate fakes

### DIFF
--- a/composeApp/src/commonMain/kotlin/coredevices/coreapp/ui/screens/BugReportScreen.kt
+++ b/composeApp/src/commonMain/kotlin/coredevices/coreapp/ui/screens/BugReportScreen.kt
@@ -87,6 +87,7 @@ import coredevices.pebble.rememberLibPebble
 import coredevices.pebble.ui.TopBarIconButtonWithToolTip
 import coredevices.pebble.ui.toPngBytes
 import io.rebble.libpebblecommon.connection.ConnectedPebble
+import io.rebble.libpebblecommon.util.toImageBitmap
 import coredevices.ui.CoreLinearProgressIndicator
 import coredevices.ui.PebbleElevatedButton
 import coredevices.ui.SignInDialog
@@ -460,7 +461,7 @@ fun BugReportScreen(
                         screenshotLoading = true
                         scope.launch {
                             try {
-                                watchScreenshot = connectedScreenshotWatch.takeScreenshot()
+                                watchScreenshot = connectedScreenshotWatch.takeScreenshot()?.toImageBitmap()
                             } catch (e: Exception) {
                                 Logger.withTag("BugReportScreen").e(e) { "Failed to capture screenshot" }
                             } finally {

--- a/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/contacts/AndroidSystemContacts.kt
+++ b/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/contacts/AndroidSystemContacts.kt
@@ -9,13 +9,13 @@ import android.graphics.BitmapFactory
 import android.os.Handler
 import android.os.Looper
 import android.provider.ContactsContract
-import androidx.compose.ui.graphics.ImageBitmap
-import androidx.compose.ui.graphics.asImageBitmap
 import co.touchlab.kermit.Logger
 import io.rebble.libpebblecommon.connection.AppContext
 import io.rebble.libpebblecommon.contacts.SystemContact
 import io.rebble.libpebblecommon.contacts.SystemContacts
 import io.rebble.libpebblecommon.di.LibPebbleCoroutineScope
+import io.rebble.libpebblecommon.image.PebbleBitmap
+import io.rebble.libpebblecommon.util.toPebbleBitmap
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
@@ -50,7 +50,7 @@ class AndroidSystemContacts(
         return flow
     }
 
-    override suspend fun getContactImage(lookupKey: String): ImageBitmap? = try {
+    override suspend fun getContactImage(lookupKey: String): PebbleBitmap? = try {
         val contactId = contentResolver.query(
             ContactsContract.Contacts.CONTENT_URI,
             arrayOf(ContactsContract.Contacts._ID),
@@ -70,7 +70,7 @@ class AndroidSystemContacts(
 
         ContactsContract.Contacts.openContactPhotoInputStream(contentResolver,
             ContentUris.withAppendedId(ContactsContract.Contacts.CONTENT_URI, contactId))?.use { inputStream ->
-            return BitmapFactory.decodeStream(inputStream).asImageBitmap()
+            return BitmapFactory.decodeStream(inputStream).toPebbleBitmap()
         }
 
         return null

--- a/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/notification/PlatformNotificationListener.main~1.kt
+++ b/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/notification/PlatformNotificationListener.main~1.kt
@@ -4,45 +4,36 @@ import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
-import androidx.compose.ui.graphics.ImageBitmap
-import androidx.compose.ui.graphics.asImageBitmap
-import androidx.compose.ui.graphics.painter.BitmapPainter
-import androidx.compose.ui.graphics.painter.Painter
 import io.rebble.libpebblecommon.connection.AppContext
-import io.rebble.libpebblecommon.notification.DrawableConverter.convertDrawableToPainter
+import io.rebble.libpebblecommon.image.PebbleBitmap
+import io.rebble.libpebblecommon.util.toPebbleBitmap
 
-actual fun iconFor(packageName: String, appContext: AppContext): ImageBitmap? {
+actual fun iconFor(packageName: String, appContext: AppContext): PebbleBitmap? {
     return try {
-        appContext.context.packageManager.getApplicationIcon(packageName).convertDrawableToPainter()
+        appContext.context.packageManager.getApplicationIcon(packageName).toBitmap().toPebbleBitmap()
     } catch (e: Exception) {
         null
     }
 }
 
-object DrawableConverter {
-    fun Drawable.convertDrawableToPainter(): ImageBitmap {
-        return toBitmap().asImageBitmap()
+private fun Drawable.toBitmap(): Bitmap {
+    if (this is BitmapDrawable && this.bitmap != null) {
+        return this.bitmap
     }
 
-    private fun Drawable.toBitmap(): Bitmap {
-        if (this is BitmapDrawable && this.bitmap != null) {
-            return this.bitmap
-        }
-
-        val bitmap = if (intrinsicWidth <= 0 || intrinsicHeight <= 0) {
-            Bitmap.createBitmap(
-                1,
-                1,
-                Bitmap.Config.ARGB_8888
-            ) // Single color bitmap will be created of 1x1 pixel
-        } else {
-            Bitmap.createBitmap(intrinsicWidth, intrinsicHeight, Bitmap.Config.ARGB_8888)
-        }
-
-        val canvas = Canvas(bitmap)
-        setBounds(0, 0, canvas.width, canvas.height)
-        draw(canvas)
-
-        return bitmap
+    val bitmap = if (intrinsicWidth <= 0 || intrinsicHeight <= 0) {
+        Bitmap.createBitmap(
+            1,
+            1,
+            Bitmap.Config.ARGB_8888
+        ) // Single color bitmap will be created of 1x1 pixel
+    } else {
+        Bitmap.createBitmap(intrinsicWidth, intrinsicHeight, Bitmap.Config.ARGB_8888)
     }
+
+    val canvas = Canvas(bitmap)
+    setBounds(0, 0, canvas.width, canvas.height)
+    draw(canvas)
+
+    return bitmap
 }

--- a/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/util/BitmapUtil.android.kt
+++ b/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/util/BitmapUtil.android.kt
@@ -4,6 +4,14 @@ import android.graphics.Bitmap
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
 import co.touchlab.kermit.Logger
+import io.rebble.libpebblecommon.image.PebbleBitmap
+
+fun Bitmap.toPebbleBitmap(): PebbleBitmap {
+    val argb = if (config == Bitmap.Config.ARGB_8888) this else copy(Bitmap.Config.ARGB_8888, false)
+    val pixels = IntArray(argb.width * argb.height)
+    argb.getPixels(pixels, 0, argb.width, 0, 0, argb.width, argb.height)
+    return PebbleBitmap(width = argb.width, height = argb.height, pixels = pixels)
+}
 
 actual fun createImageBitmapFromPixelArray(
     pixels: IntArray,

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/connection/FakeConnectedDevice.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/connection/FakeConnectedDevice.kt
@@ -1,0 +1,181 @@
+package io.rebble.libpebblecommon.connection
+
+import io.rebble.libpebblecommon.connection.endpointmanager.FirmwareUpdater
+import io.rebble.libpebblecommon.connection.endpointmanager.InstalledLanguagePack
+import io.rebble.libpebblecommon.connection.endpointmanager.LanguagePackInstallState
+import io.rebble.libpebblecommon.connection.endpointmanager.musiccontrol.MusicTrack
+import io.rebble.libpebblecommon.image.PebbleBitmap
+import io.rebble.libpebblecommon.js.PKJSApp
+import io.rebble.libpebblecommon.metadata.WatchColor
+import io.rebble.libpebblecommon.metadata.WatchHardwarePlatform
+import io.rebble.libpebblecommon.music.MusicAction
+import io.rebble.libpebblecommon.music.PlaybackState
+import io.rebble.libpebblecommon.music.RepeatType
+import io.rebble.libpebblecommon.packets.ProtocolCapsFlag
+import io.rebble.libpebblecommon.protocolhelpers.PebblePacket
+import io.rebble.libpebblecommon.services.FirmwareVersion
+import io.rebble.libpebblecommon.services.WatchInfo
+import io.rebble.libpebblecommon.services.appmessage.AppMessageData
+import io.rebble.libpebblecommon.services.appmessage.AppMessageResult
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.io.files.Path
+import kotlin.random.Random
+import kotlin.time.Instant
+import kotlin.uuid.Uuid
+
+class FakeConnectedDevice(
+    override val identifier: PebbleIdentifier,
+    override val firmwareUpdateAvailable: FirmwareUpdateCheckState,
+    override val firmwareUpdateState: FirmwareUpdater.FirmwareUpdateStatus,
+    override val name: String,
+    override val nickname: String?,
+    override val color: WatchColor = run {
+        val white = Random.nextBoolean()
+        if (white) {
+            WatchColor.Pebble2DuoWhite
+        } else {
+            WatchColor.Pebble2DuoBlack
+        }
+    },
+    override val watchType: WatchHardwarePlatform = WatchHardwarePlatform.CORE_ASTERIX,
+    override val lastConnected: Instant = Instant.DISTANT_PAST,
+    override val serial: String = "XXXXXXXXXXXX",
+    override val runningFwVersion: String = "v1.2.3-core",
+    override val connectionFailureInfo: ConnectionFailureInfo?,
+    override val usingBtClassic: Boolean = false,
+    override val capabilities: Set<ProtocolCapsFlag> = emptySet()
+) : ConnectedPebbleDevice {
+
+    override fun forget() {}
+    override fun setNickname(nickname: String?) {
+    }
+
+    override fun connect() {}
+
+    override fun disconnect() {}
+
+    override suspend fun sendPing(cookie: UInt): UInt = cookie
+
+    override fun resetIntoPrf() {}
+
+    override fun createCoreDump() {}
+    override fun factoryReset() {}
+
+    override suspend fun sendPPMessage(bytes: ByteArray) {}
+
+    override suspend fun sendPPMessage(ppMessage: PebblePacket) {}
+
+    override val inboundMessages: Flow<PebblePacket> = MutableSharedFlow()
+    override val rawInboundMessages: Flow<ByteArray> = MutableSharedFlow()
+
+    override fun sideloadFirmware(path: Path) {}
+
+    override fun updateFirmware(update: FirmwareUpdateCheckResult.FoundUpdate) {}
+
+    override fun checkforFirmwareUpdate() {}
+
+    override suspend fun launchApp(uuid: Uuid) {}
+
+    override suspend fun stopApp(uuid: Uuid) {}
+
+    override val runningApp: StateFlow<Uuid?> = MutableStateFlow(null)
+    override val watchInfo: WatchInfo = WatchInfo(
+        runningFwVersion = FirmwareVersion.from(
+            runningFwVersion,
+            isRecovery = false,
+            gitHash = "",
+            timestamp = kotlin.time.Instant.DISTANT_PAST,
+            isDualSlot = false,
+            isSlot0 = false,
+        )!!,
+        recoveryFwVersion = FirmwareVersion.from(
+            runningFwVersion,
+            isRecovery = true,
+            gitHash = "",
+            timestamp = kotlin.time.Instant.DISTANT_PAST,
+            isDualSlot = false,
+            isSlot0 = false,
+        )!!,
+        platform = watchType,
+        bootloaderTimestamp = kotlin.time.Instant.DISTANT_PAST,
+        board = "board",
+        serial = serial,
+        btAddress = "11:22:33:44:55:66",
+        resourceCrc = -9999999,
+        resourceTimestamp = kotlin.time.Instant.DISTANT_PAST,
+        language = "en-GB",
+        languageVersion = 1,
+        capabilities = emptySet(),
+        isUnfaithful = false,
+        healthInsightsVersion = null,
+        javascriptVersion = null,
+        color = color,
+    )
+
+    override suspend fun updateTime() {}
+    override suspend fun updateTimeIfNeeded() {}
+
+    override fun inboundAppMessages(appUuid: Uuid): Flow<AppMessageData> {
+        return MutableSharedFlow()
+    }
+
+    override val transactionSequence: Iterator<UByte> = iterator { }
+
+    override suspend fun sendAppMessage(appMessageData: AppMessageData): AppMessageResult =
+        AppMessageResult.ACK(appMessageData.transactionId)
+
+    override suspend fun sendAppMessageResult(appMessageResult: AppMessageResult) {}
+
+    override suspend fun gatherLogs(): Path? = null
+
+    override suspend fun getCoreDump(unread: Boolean): Path? = null
+
+    override suspend fun updateTrack(track: MusicTrack) {}
+
+    override suspend fun updatePlaybackState(
+        state: PlaybackState,
+        trackPosMs: UInt,
+        playbackRatePct: UInt,
+        shuffle: Boolean,
+        repeatType: RepeatType
+    ) {
+    }
+
+    override suspend fun updatePlayerInfo(packageId: String, name: String) {}
+
+    override suspend fun updateVolumeInfo(volumePercent: UByte) {}
+
+    override val musicActions: Flow<MusicAction> = MutableSharedFlow()
+    override val updateRequestTrigger: Flow<Unit> = MutableSharedFlow()
+
+    @Deprecated("Use more generic currentCompanionAppSession instead and cast if necessary")
+    override val currentPKJSSession: StateFlow<PKJSApp?> = MutableStateFlow(null)
+    override val currentCompanionAppSessions: StateFlow<List<CompanionApp>> = MutableStateFlow(emptyList())
+
+    override suspend fun startDevConnection() {}
+    override suspend fun stopDevConnection() {}
+    override val devConnectionActive: StateFlow<Boolean> = MutableStateFlow(false)
+    override val batteryLevel: Int? = 50
+    override suspend fun takeScreenshot(): PebbleBitmap {
+        // Return an orange square as a placeholder
+        val width = 144
+        val height = 168
+        val pixels = IntArray(width * height) { 0xFFFA4A36.toInt() }
+        return PebbleBitmap(width, height, pixels)
+    }
+
+    override fun installLanguagePack(path: Path, name: String) {
+    }
+
+    override fun installLanguagePack(url: String, name: String) {
+    }
+
+    override val languagePackInstallState: LanguagePackInstallState =
+        LanguagePackInstallState.Idle()
+    override val installedLanguagePack: InstalledLanguagePack? = null
+
+    override suspend fun requestHealthData(fullSync: Boolean): Boolean = true
+}

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/connection/LibPebble.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/connection/LibPebble.kt
@@ -1,8 +1,5 @@
 package io.rebble.libpebblecommon.connection
 
-import androidx.compose.runtime.Stable
-import androidx.compose.ui.graphics.ImageBitmap
-import androidx.paging.PagingSource
 import co.touchlab.kermit.Logger
 import io.rebble.libpebblecommon.ErrorTracker
 import io.rebble.libpebblecommon.Housekeeping
@@ -17,11 +14,11 @@ import io.rebble.libpebblecommon.connection.bt.BluetoothStateProvider
 import io.rebble.libpebblecommon.connection.bt.ble.transport.GattServerManager
 import io.rebble.libpebblecommon.connection.endpointmanager.timeline.ActionOverrides
 import io.rebble.libpebblecommon.connection.endpointmanager.timeline.CustomTimelineActionHandler
+import io.rebble.libpebblecommon.contacts.Contacts
 import io.rebble.libpebblecommon.contacts.PhoneContactsSyncer
 import io.rebble.libpebblecommon.database.dao.AppWithCount
 import io.rebble.libpebblecommon.database.dao.ChannelAndCount
 import io.rebble.libpebblecommon.database.dao.HealthDao
-import io.rebble.libpebblecommon.database.dao.ContactWithCount
 import io.rebble.libpebblecommon.database.dao.TimelineNotificationRealDao
 import io.rebble.libpebblecommon.database.dao.VibePatternDao
 import io.rebble.libpebblecommon.database.dao.WatchPreference
@@ -41,6 +38,7 @@ import io.rebble.libpebblecommon.di.initKoin
 import io.rebble.libpebblecommon.health.Health
 import io.rebble.libpebblecommon.health.HealthDebugStats
 import io.rebble.libpebblecommon.health.HealthSettings
+import io.rebble.libpebblecommon.image.PebbleBitmap
 import io.rebble.libpebblecommon.js.InjectedPKJSHttpInterceptors
 import io.rebble.libpebblecommon.js.JsTokenUtil
 import io.rebble.libpebblecommon.locker.AppBasicProperties
@@ -85,7 +83,6 @@ sealed class PebbleConnectionEvent {
     data class PebbleDisconnectedEvent(val identifier: PebbleIdentifier) : PebbleConnectionEvent()
 }
 
-@Stable
 interface LibPebble : Scanning, RequestSync, LockerApi, NotificationApps, CallManagement, Calendar,
     OtherPebbleApps, PKJSToken, Watches, Errors, Contacts, AnalyticsEvents, HealthApi, WatchPrefs,
     SystemGeolocation, Timeline, Vibrations, Weather, HealthDataApi {
@@ -305,14 +302,6 @@ interface LockerApi {
     val activeWatchface: StateFlow<LockerWrapper?>
 }
 
-interface Contacts {
-    fun getContactsWithCounts(searchTerm: String, onlyNotified: Boolean): PagingSource<Int, ContactWithCount>
-    fun getContact(id: String): Flow<ContactWithCount?>
-    fun updateContactState(contactId: String, muteState: MuteState, vibePatternName: String?)
-    suspend fun getContactImage(lookupKey: String): ImageBitmap?
-}
-
-@Stable
 interface NotificationApps {
     fun notificationApps(): Flow<List<AppWithCount>>
     fun notificationAppChannelCounts(packageName: String): Flow<List<ChannelAndCount>>
@@ -341,7 +330,7 @@ interface NotificationApps {
     fun deleteNotificationRule(rule: NotificationRuleEntity)
 
     /** Will only return a value on Android */
-    suspend fun getAppIcon(packageName: String): ImageBitmap?
+    suspend fun getAppIcon(packageName: String): PebbleBitmap?
 }
 
 interface Vibrations {
@@ -365,7 +354,7 @@ interface PKJSToken {
 
 // Impl
 
-class LibPebble3(
+class LibPebble3 internal constructor(
     private val watchManager: WatchManager,
     private val scanning: Scanning,
     private val locker: Locker,

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/connection/PebbleDevice.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/connection/PebbleDevice.kt
@@ -1,12 +1,11 @@
 package io.rebble.libpebblecommon.connection
 
-import androidx.compose.runtime.Stable
-import androidx.compose.ui.graphics.ImageBitmap
 import io.rebble.libpebblecommon.connection.bt.ble.pebble.PebbleLeScanRecord
 import io.rebble.libpebblecommon.connection.endpointmanager.FirmwareUpdater
 import io.rebble.libpebblecommon.connection.endpointmanager.InstalledLanguagePack
 import io.rebble.libpebblecommon.connection.endpointmanager.LanguagePackInstallState
 import io.rebble.libpebblecommon.connection.endpointmanager.musiccontrol.MusicTrack
+import io.rebble.libpebblecommon.image.PebbleBitmap
 import io.rebble.libpebblecommon.js.PKJSApp
 import io.rebble.libpebblecommon.metadata.WatchColor
 import io.rebble.libpebblecommon.metadata.WatchHardwarePlatform
@@ -36,7 +35,6 @@ data class ConnectionFailureInfo(
 )
 
 // <T : Transport> ?
-@Stable
 sealed interface PebbleDevice {
     val identifier: PebbleIdentifier
     val name: String
@@ -145,7 +143,7 @@ object ConnectedPebble {
     }
 
     interface Screenshot {
-        suspend fun takeScreenshot(): ImageBitmap?
+        suspend fun takeScreenshot(): PebbleBitmap?
     }
 
     interface Logs {

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/contacts/Contacts.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/contacts/Contacts.kt
@@ -1,0 +1,14 @@
+package io.rebble.libpebblecommon.contacts
+
+import androidx.paging.PagingSource
+import io.rebble.libpebblecommon.database.dao.ContactWithCount
+import io.rebble.libpebblecommon.database.entity.MuteState
+import io.rebble.libpebblecommon.image.PebbleBitmap
+import kotlinx.coroutines.flow.Flow
+
+interface Contacts {
+    fun getContactsWithCounts(searchTerm: String, onlyNotified: Boolean): PagingSource<Int, ContactWithCount>
+    fun getContact(id: String): Flow<ContactWithCount?>
+    fun updateContactState(contactId: String, muteState: MuteState, vibePatternName: String?)
+    suspend fun getContactImage(lookupKey: String): PebbleBitmap?
+}

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/contacts/PhoneContactsSyncer.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/contacts/PhoneContactsSyncer.kt
@@ -1,11 +1,11 @@
 package io.rebble.libpebblecommon.contacts
 
-import androidx.compose.ui.graphics.ImageBitmap
 import co.touchlab.kermit.Logger
 import io.rebble.libpebblecommon.database.dao.ContactDao
 import io.rebble.libpebblecommon.database.entity.ContactEntity
 import io.rebble.libpebblecommon.database.entity.MuteState
 import io.rebble.libpebblecommon.di.LibPebbleCoroutineScope
+import io.rebble.libpebblecommon.image.PebbleBitmap
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -24,7 +24,7 @@ interface SystemContacts {
     fun registerForContactsChanges(): Flow<Unit>
     suspend fun getContacts(): List<SystemContact>
     fun hasPermission(): Boolean
-    suspend fun getContactImage(lookupKey: String): ImageBitmap?
+    suspend fun getContactImage(lookupKey: String): PebbleBitmap?
 }
 
 class PhoneContactsSyncer(

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/di/LibPebbleModule.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/di/LibPebbleModule.kt
@@ -20,7 +20,6 @@ import io.rebble.libpebblecommon.calls.MissedCallSyncer
 import io.rebble.libpebblecommon.connection.AnalyticsEvents
 import io.rebble.libpebblecommon.connection.AppContext
 import io.rebble.libpebblecommon.connection.ConnectionFailureHandler
-import io.rebble.libpebblecommon.connection.Contacts
 import io.rebble.libpebblecommon.connection.CreatePlatformIdentifier
 import io.rebble.libpebblecommon.connection.LegacyBtClassicMigrator
 import io.rebble.libpebblecommon.connection.LibPebble
@@ -93,6 +92,7 @@ import io.rebble.libpebblecommon.connection.endpointmanager.phonecontrol.PhoneCo
 import io.rebble.libpebblecommon.connection.endpointmanager.putbytes.PutBytesSession
 import io.rebble.libpebblecommon.connection.endpointmanager.timeline.ActionOverrides
 import io.rebble.libpebblecommon.connection.endpointmanager.timeline.TimelineActionManager
+import io.rebble.libpebblecommon.contacts.Contacts
 import io.rebble.libpebblecommon.contacts.PhoneContactsSyncer
 import io.rebble.libpebblecommon.database.BlobDbDatabaseManager
 import io.rebble.libpebblecommon.database.Database

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/fake/FakeLibPebble.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/fake/FakeLibPebble.kt
@@ -1,11 +1,11 @@
-package io.rebble.libpebblecommon.connection
+package io.rebble.libpebblecommon.fake
 
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.ImageBitmap
-import androidx.compose.ui.graphics.toArgb
 import androidx.paging.PagingSource
 import io.ktor.util.PlatformUtils
 import io.rebble.libpebblecommon.LibPebbleConfig
+import io.rebble.libpebblecommon.connection.*
+import io.rebble.libpebblecommon.contacts.Contacts
+import io.rebble.libpebblecommon.image.PebbleBitmap
 import io.rebble.libpebblecommon.calls.Call
 import io.rebble.libpebblecommon.connection.bt.BluetoothState
 import io.rebble.libpebblecommon.connection.endpointmanager.FirmwareUpdater
@@ -299,12 +299,12 @@ class FakeLibPebble : LibPebble {
         // No-op
     }
 
-    override suspend fun getAppIcon(packageName: String): ImageBitmap? {
+    override suspend fun getAppIcon(packageName: String): PebbleBitmap? {
         // Return a green square as a placeholder
         val width = 48
         val height = 48
-        val buffer = IntArray(width * height) { Color.Green.toArgb() }
-        return ImageBitmap(width, height).apply { readPixels(buffer) }
+        val pixels = IntArray(width * height) { 0xFF00FF00.toInt() }
+        return PebbleBitmap(width, height, pixels)
     }
 
     // CallManagement interface
@@ -345,7 +345,7 @@ class FakeLibPebble : LibPebble {
     ) {
     }
 
-    override suspend fun getContactImage(lookupKey: String): ImageBitmap? {
+    override suspend fun getContactImage(lookupKey: String): PebbleBitmap? {
         return null
     }
 
@@ -555,160 +555,6 @@ fun fakeWatch(connected: Boolean = Random.nextBoolean()): PebbleDevice {
             }
         }
     }
-}
-
-class FakeConnectedDevice(
-    override val identifier: PebbleIdentifier,
-    override val firmwareUpdateAvailable: FirmwareUpdateCheckState,
-    override val firmwareUpdateState: FirmwareUpdater.FirmwareUpdateStatus,
-    override val name: String,
-    override val nickname: String?,
-    override val color: WatchColor = run {
-        val white = Random.nextBoolean()
-        if (white) {
-            WatchColor.Pebble2DuoWhite
-        } else {
-            WatchColor.Pebble2DuoBlack
-        }
-    },
-    override val watchType: WatchHardwarePlatform = WatchHardwarePlatform.CORE_ASTERIX,
-    override val lastConnected: Instant = Instant.DISTANT_PAST,
-    override val serial: String = "XXXXXXXXXXXX",
-    override val runningFwVersion: String = "v1.2.3-core",
-    override val connectionFailureInfo: ConnectionFailureInfo?,
-    override val usingBtClassic: Boolean = false,
-    override val capabilities: Set<ProtocolCapsFlag> = emptySet()
-) : ConnectedPebbleDevice {
-
-    override fun forget() {}
-    override fun setNickname(nickname: String?) {
-    }
-
-    override fun connect() {}
-
-    override fun disconnect() {}
-
-    override suspend fun sendPing(cookie: UInt): UInt = cookie
-
-    override fun resetIntoPrf() {}
-
-    override fun createCoreDump() {}
-    override fun factoryReset() {}
-
-    override suspend fun sendPPMessage(bytes: ByteArray) {}
-
-    override suspend fun sendPPMessage(ppMessage: PebblePacket) {}
-
-    override val inboundMessages: Flow<PebblePacket> = MutableSharedFlow()
-    override val rawInboundMessages: Flow<ByteArray> = MutableSharedFlow()
-
-    override fun sideloadFirmware(path: Path) {}
-
-    override fun updateFirmware(update: FirmwareUpdateCheckResult.FoundUpdate) {}
-
-    override fun checkforFirmwareUpdate() {}
-
-    override suspend fun launchApp(uuid: Uuid) {}
-
-    override suspend fun stopApp(uuid: Uuid) {}
-
-    override val runningApp: StateFlow<Uuid?> = MutableStateFlow(null)
-    override val watchInfo: WatchInfo = WatchInfo(
-        runningFwVersion = FirmwareVersion.from(
-            runningFwVersion,
-            isRecovery = false,
-            gitHash = "",
-            timestamp = kotlin.time.Instant.DISTANT_PAST,
-            isDualSlot = false,
-            isSlot0 = false,
-        )!!,
-        recoveryFwVersion = FirmwareVersion.from(
-            runningFwVersion,
-            isRecovery = true,
-            gitHash = "",
-            timestamp = kotlin.time.Instant.DISTANT_PAST,
-            isDualSlot = false,
-            isSlot0 = false,
-        )!!,
-        platform = watchType,
-        bootloaderTimestamp = kotlin.time.Instant.DISTANT_PAST,
-        board = "board",
-        serial = serial,
-        btAddress = "11:22:33:44:55:66",
-        resourceCrc = -9999999,
-        resourceTimestamp = kotlin.time.Instant.DISTANT_PAST,
-        language = "en-GB",
-        languageVersion = 1,
-        capabilities = emptySet(),
-        isUnfaithful = false,
-        healthInsightsVersion = null,
-        javascriptVersion = null,
-        color = color,
-    )
-
-    override suspend fun updateTime() {}
-    override suspend fun updateTimeIfNeeded() {}
-
-    override fun inboundAppMessages(appUuid: Uuid): Flow<AppMessageData> {
-        return MutableSharedFlow()
-    }
-
-    override val transactionSequence: Iterator<UByte> = iterator { }
-
-    override suspend fun sendAppMessage(appMessageData: AppMessageData): AppMessageResult =
-        AppMessageResult.ACK(appMessageData.transactionId)
-
-    override suspend fun sendAppMessageResult(appMessageResult: AppMessageResult) {}
-
-    override suspend fun gatherLogs(): Path? = null
-
-    override suspend fun getCoreDump(unread: Boolean): Path? = null
-
-    override suspend fun updateTrack(track: MusicTrack) {}
-
-    override suspend fun updatePlaybackState(
-        state: PlaybackState,
-        trackPosMs: UInt,
-        playbackRatePct: UInt,
-        shuffle: Boolean,
-        repeatType: RepeatType
-    ) {
-    }
-
-    override suspend fun updatePlayerInfo(packageId: String, name: String) {}
-
-    override suspend fun updateVolumeInfo(volumePercent: UByte) {}
-
-    override val musicActions: Flow<MusicAction> = MutableSharedFlow()
-    override val updateRequestTrigger: Flow<Unit> = MutableSharedFlow()
-
-    @Deprecated("Use more generic currentCompanionAppSession instead and cast if necessary")
-    override val currentPKJSSession: StateFlow<PKJSApp?> = MutableStateFlow(null)
-    override val currentCompanionAppSessions: StateFlow<List<CompanionApp>> = MutableStateFlow(emptyList())
-
-    override suspend fun startDevConnection() {}
-    override suspend fun stopDevConnection() {}
-    override val devConnectionActive: StateFlow<Boolean> = MutableStateFlow(false)
-    override val batteryLevel: Int? = 50
-    override suspend fun takeScreenshot(): ImageBitmap {
-        // Return an orange square as a placeholder
-        val width = 144
-        val height = 168
-        val buffer = IntArray(width * height) { Color(0xFFFA4A36).toArgb() }
-        return ImageBitmap(width, height).apply { readPixels(buffer) }
-    }
-
-    override fun installLanguagePack(path: Path, name: String) {
-    }
-
-    override fun installLanguagePack(url: String, name: String) {
-    }
-
-    override val languagePackInstallState: LanguagePackInstallState =
-        LanguagePackInstallState.Idle()
-    override val installedLanguagePack: InstalledLanguagePack? = null
-
-    override suspend fun requestHealthData(fullSync: Boolean): Boolean = true
 }
 
 class FakeConnectedDeviceInRecovery(

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/image/PebbleBitmap.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/image/PebbleBitmap.kt
@@ -1,0 +1,20 @@
+package io.rebble.libpebblecommon.image
+
+class PebbleBitmap(
+    val width: Int,
+    val height: Int,
+    val pixels: IntArray,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is PebbleBitmap) return false
+        return width == other.width && height == other.height && pixels.contentEquals(other.pixels)
+    }
+
+    override fun hashCode(): Int {
+        var result = width
+        result = 31 * result + height
+        result = 31 * result + pixels.contentHashCode()
+        return result
+    }
+}

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/notification/ContactsApi.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/notification/ContactsApi.kt
@@ -1,13 +1,13 @@
 package io.rebble.libpebblecommon.notification
 
-import androidx.compose.ui.graphics.ImageBitmap
 import androidx.paging.PagingSource
-import io.rebble.libpebblecommon.connection.Contacts
+import io.rebble.libpebblecommon.contacts.Contacts
 import io.rebble.libpebblecommon.contacts.SystemContacts
 import io.rebble.libpebblecommon.database.dao.ContactDao
 import io.rebble.libpebblecommon.database.dao.ContactWithCount
 import io.rebble.libpebblecommon.database.entity.MuteState
 import io.rebble.libpebblecommon.di.LibPebbleCoroutineScope
+import io.rebble.libpebblecommon.image.PebbleBitmap
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 
@@ -34,7 +34,7 @@ class ContactsApi(
         }
     }
 
-    override suspend fun getContactImage(lookupKey: String): ImageBitmap? {
+    override suspend fun getContactImage(lookupKey: String): PebbleBitmap? {
         return systemContacts.getContactImage(lookupKey)
     }
 }

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/notification/PlatformNotificationListener.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/notification/PlatformNotificationListener.kt
@@ -1,6 +1,5 @@
 package io.rebble.libpebblecommon.notification
 
-import androidx.compose.ui.graphics.ImageBitmap
 import io.rebble.libpebblecommon.connection.AppContext
 import io.rebble.libpebblecommon.connection.LibPebble
 import io.rebble.libpebblecommon.connection.NotificationApps
@@ -17,6 +16,7 @@ import io.rebble.libpebblecommon.database.entity.MuteState
 import io.rebble.libpebblecommon.database.entity.NotificationEntity
 import io.rebble.libpebblecommon.database.entity.VibePatternEntity
 import io.rebble.libpebblecommon.di.LibPebbleCoroutineScope
+import io.rebble.libpebblecommon.image.PebbleBitmap
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.Flow
@@ -142,7 +142,7 @@ class NotificationApi(
         }
     }
 
-    override suspend fun getAppIcon(packageName: String): ImageBitmap? {
+    override suspend fun getAppIcon(packageName: String): PebbleBitmap? {
         return withContext(Dispatchers.IO) {
             iconFor(packageName, appContext)
         }
@@ -180,4 +180,4 @@ class NotificationApi(
     }
 }
 
-expect fun iconFor(packageName: String, appContext: AppContext): ImageBitmap?
+expect fun iconFor(packageName: String, appContext: AppContext): PebbleBitmap?

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/services/ScreenshotService.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/services/ScreenshotService.kt
@@ -1,12 +1,10 @@
 package io.rebble.libpebblecommon.services
 
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.ImageBitmap
-import androidx.compose.ui.graphics.toArgb
 import co.touchlab.kermit.Logger
 import io.rebble.libpebblecommon.connection.ConnectedPebble
 import io.rebble.libpebblecommon.connection.PebbleProtocolHandler
 import io.rebble.libpebblecommon.di.ConnectionCoroutineScope
+import io.rebble.libpebblecommon.image.PebbleBitmap
 import io.rebble.libpebblecommon.packets.ScreenshotData
 import io.rebble.libpebblecommon.packets.ScreenshotHeader
 import io.rebble.libpebblecommon.packets.ScreenshotRequest
@@ -14,7 +12,6 @@ import io.rebble.libpebblecommon.packets.ScreenshotResponseCode
 import io.rebble.libpebblecommon.packets.ScreenshotVersion
 import io.rebble.libpebblecommon.protocolhelpers.PebblePacket.Companion.deserialize
 import io.rebble.libpebblecommon.util.DataBuffer
-import io.rebble.libpebblecommon.util.createImageBitmapFromPixelArray
 import io.rebble.libpebblecommon.util.isScreenshotFinished
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
@@ -36,7 +33,7 @@ class ScreenshotService(
     private val logger = Logger.withTag("ScreenshotService")
     private val state = MutableStateFlow(ScreenshotState.Idle)
 
-    override suspend fun takeScreenshot(): ImageBitmap? =
+    override suspend fun takeScreenshot(): PebbleBitmap? =
         withContext(connectionCoroutineScope.coroutineContext + Dispatchers.IO) {
             try {
                 if (state.value == ScreenshotState.Busy) {
@@ -111,10 +108,10 @@ class ScreenshotService(
                                     val bitIndex = x % 8
                                     val bit = (bytes[byteIndex].toInt() shr bitIndex) and 1
                                     val index = (y * finalHeader.width) + x
-                                    pixels[index] = if (bit == 0) Color.Black.toArgb() else Color.White.toArgb()
+                                    pixels[index] = if (bit == 0) 0xFF000000.toInt() else 0xFFFFFFFF.toInt()
                                 }
                             }
-                            createImageBitmapFromPixelArray(pixels = pixels, width = finalHeader.width, height = finalHeader.height)
+                            PebbleBitmap(width = finalHeader.width, height = finalHeader.height, pixels = pixels)
                         }
                         ScreenshotVersion.COLOR_8_BIT -> {
                             val buffer = data ?: throw IllegalStateException("data buffer is null")
@@ -137,7 +134,7 @@ class ScreenshotService(
                                     pixels[index] = color
                                 }
                             }
-                            createImageBitmapFromPixelArray(pixels = pixels, width = finalHeader.width, height = finalHeader.height)
+                            PebbleBitmap(width = finalHeader.width, height = finalHeader.height, pixels = pixels)
                         }
                     }
                 } else {

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/util/BitmapUtil.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/util/BitmapUtil.kt
@@ -1,12 +1,16 @@
 package io.rebble.libpebblecommon.util
 
 import androidx.compose.ui.graphics.ImageBitmap
+import io.rebble.libpebblecommon.image.PebbleBitmap
 
 expect fun createImageBitmapFromPixelArray(
     pixels: IntArray,
     width: Int,
     height: Int
 ): ImageBitmap?
+
+fun PebbleBitmap.toImageBitmap(): ImageBitmap? =
+    createImageBitmapFromPixelArray(pixels = pixels, width = width, height = height)
 
 expect fun isScreenshotFinished(
     buffer: DataBuffer,

--- a/libpebble3/src/commonTest/kotlin/io/rebble/libpebblecommon/js/PKJSRunnerTests.kt
+++ b/libpebble3/src/commonTest/kotlin/io/rebble/libpebblecommon/js/PKJSRunnerTests.kt
@@ -2,9 +2,9 @@ package io.rebble.libpebblecommon.js
 
 import io.rebble.libpebblecommon.connection.ConnectedPebbleDevice
 import io.rebble.libpebblecommon.connection.FakeAppMessages
-import io.rebble.libpebblecommon.connection.FakeLibPebble
 import io.rebble.libpebblecommon.connection.LibPebble
-import io.rebble.libpebblecommon.connection.fakeWatch
+import io.rebble.libpebblecommon.fake.FakeLibPebble
+import io.rebble.libpebblecommon.fake.fakeWatch
 import io.rebble.libpebblecommon.database.entity.LockerEntry
 import io.rebble.libpebblecommon.metadata.pbw.appinfo.PbwAppInfo
 import io.rebble.libpebblecommon.metadata.pbw.appinfo.Resources

--- a/libpebble3/src/iosMain/kotlin/io/rebble/libpebblecommon/contacts/IosSystemContacts.kt
+++ b/libpebble3/src/iosMain/kotlin/io/rebble/libpebblecommon/contacts/IosSystemContacts.kt
@@ -1,8 +1,8 @@
 package io.rebble.libpebblecommon.io.rebble.libpebblecommon.contacts
 
-import androidx.compose.ui.graphics.ImageBitmap
 import io.rebble.libpebblecommon.contacts.SystemContact
 import io.rebble.libpebblecommon.contacts.SystemContacts
+import io.rebble.libpebblecommon.image.PebbleBitmap
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
@@ -19,7 +19,7 @@ class IosSystemContacts : SystemContacts {
         return false
     }
 
-    override suspend fun getContactImage(lookupKey: String): ImageBitmap? {
+    override suspend fun getContactImage(lookupKey: String): PebbleBitmap? {
         return null
     }
 }

--- a/libpebble3/src/iosMain/kotlin/io/rebble/libpebblecommon/notification/PlatformNotificationListener.ios.kt
+++ b/libpebble3/src/iosMain/kotlin/io/rebble/libpebblecommon/notification/PlatformNotificationListener.ios.kt
@@ -1,6 +1,6 @@
 package io.rebble.libpebblecommon.notification
 
-import androidx.compose.ui.graphics.ImageBitmap
 import io.rebble.libpebblecommon.connection.AppContext
+import io.rebble.libpebblecommon.image.PebbleBitmap
 
-actual fun iconFor(packageName: String, appContext: AppContext): ImageBitmap? = null
+actual fun iconFor(packageName: String, appContext: AppContext): PebbleBitmap? = null

--- a/libpebble3/src/jvmMain/kotlin/io/rebble/libpebblecommon/notification/PlatformNotificationListener.jvm.kt
+++ b/libpebble3/src/jvmMain/kotlin/io/rebble/libpebblecommon/notification/PlatformNotificationListener.jvm.kt
@@ -1,6 +1,6 @@
 package io.rebble.libpebblecommon.notification
 
-import androidx.compose.ui.graphics.ImageBitmap
 import io.rebble.libpebblecommon.connection.AppContext
+import io.rebble.libpebblecommon.image.PebbleBitmap
 
-actual fun iconFor(packageName: String, appContext: AppContext): ImageBitmap? = null
+actual fun iconFor(packageName: String, appContext: AppContext): PebbleBitmap? = null

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/NotificationContactsScreen.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/NotificationContactsScreen.kt
@@ -50,6 +50,7 @@ import coredevices.pebble.rememberLibPebble
 import coredevices.ui.ShowOnceTooltipBox
 import io.rebble.libpebblecommon.database.dao.ContactWithCount
 import io.rebble.libpebblecommon.database.entity.MuteState
+import io.rebble.libpebblecommon.util.toImageBitmap
 import kotlinx.coroutines.launch
 import org.koin.compose.viewmodel.koinViewModel
 
@@ -261,7 +262,7 @@ fun ContactCard(entry: ContactWithCount, nav: NavBarNav, firstOrOnlyItem: Boolea
 fun ContactImage(entry: ContactWithCount, modifier: Modifier) {
     val libPebble = rememberLibPebble()
     val icon by produceState<ImageBitmap?>(initialValue = null, entry.contact.lookupKey) {
-        value = libPebble.getContactImage(entry.contact.lookupKey)
+        value = libPebble.getContactImage(entry.contact.lookupKey)?.toImageBitmap()
     }
     icon.let {
         if (it != null) {

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/NotificationsScreen.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/NotificationsScreen.kt
@@ -43,6 +43,7 @@ import coredevices.pebble.account.BootConfigProvider
 import coredevices.pebble.account.iconUrlFor
 import io.rebble.libpebblecommon.connection.NotificationApps
 import io.rebble.libpebblecommon.database.isAfter
+import io.rebble.libpebblecommon.util.toImageBitmap
 import io.rebble.libpebblecommon.database.dao.AppWithCount
 import io.rebble.libpebblecommon.database.entity.MuteState
 import kotlin.time.Clock
@@ -251,7 +252,7 @@ fun AppIconImage(
         // Android: load from OS
         Platform.Android -> {
             val icon by produceState<ImageBitmap?>(initialValue = null, app.packageName) {
-                value = notificationApps.getAppIcon(app.packageName)
+                value = notificationApps.getAppIcon(app.packageName)?.toImageBitmap()
             }
             icon.let {
                 if (it != null) {

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/PreviewUtil.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/PreviewUtil.kt
@@ -58,11 +58,11 @@ import coredevices.util.PermissionResult
 import coredevices.util.RequiredPermissions
 import coredevices.util.WeatherUnit
 import io.rebble.libpebblecommon.connection.AppContext
-import io.rebble.libpebblecommon.connection.FakeLibPebble
 import io.rebble.libpebblecommon.connection.FirmwareUpdateCheckResult
 import io.rebble.libpebblecommon.connection.LibPebble
 import io.rebble.libpebblecommon.connection.NotificationApps
 import io.rebble.libpebblecommon.connection.PebbleIdentifier
+import io.rebble.libpebblecommon.fake.FakeLibPebble
 import io.rebble.libpebblecommon.locker.AppType
 import io.rebble.libpebblecommon.metadata.WatchType
 import io.rebble.libpebblecommon.web.LockerAddResponse

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchesScreen.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchesScreen.kt
@@ -175,6 +175,7 @@ import io.rebble.libpebblecommon.connection.endpointmanager.FirmwareUpdateErrorS
 import io.rebble.libpebblecommon.connection.endpointmanager.FirmwareUpdater
 import io.rebble.libpebblecommon.connection.endpointmanager.LanguagePackInstallState
 import io.rebble.libpebblecommon.database.entity.buildTimelineNotification
+import io.rebble.libpebblecommon.util.toImageBitmap
 import io.rebble.libpebblecommon.packets.blobdb.TimelineIcon
 import io.rebble.libpebblecommon.packets.blobdb.TimelineItem
 import io.rebble.libpebblecommon.services.blobdb.TimelineActionResult
@@ -1730,7 +1731,7 @@ fun ScreenshotDialog(watch: ConnectedPebble.Screenshot, onDismissRequest: () -> 
 
     suspend fun takeScreenshot() {
         screenshot = null
-        screenshot = watch.takeScreenshot()
+        screenshot = watch.takeScreenshot()?.toImageBitmap()
         logger.v { "screenshot = $screenshot" }
     }
 

--- a/pebble/src/iosMain/kotlin/coredevices/pebble/actions/watch/WatchInfo.kt
+++ b/pebble/src/iosMain/kotlin/coredevices/pebble/actions/watch/WatchInfo.kt
@@ -5,6 +5,7 @@ import coredevices.util.imageBitmapToPngBytes
 import io.rebble.libpebblecommon.connection.ConnectedPebble
 import io.rebble.libpebblecommon.connection.ConnectedPebbleDevice
 import io.rebble.libpebblecommon.connection.LibPebble
+import io.rebble.libpebblecommon.util.toImageBitmap
 
 /**
  * Returns the battery level (0–100) of the connected watch, or null if no watch is connected
@@ -46,7 +47,7 @@ suspend fun getWatchScreenshotBase64(libPebble: LibPebble): String {
         .filterIsInstance<ConnectedPebbleDevice>()
         .firstOrNull()
     if (watch is ConnectedPebble.Screenshot) {
-        val bitmap = watch.takeScreenshot()
+        val bitmap = watch.takeScreenshot()?.toImageBitmap()
         if (bitmap != null) {
             return imageBitmapToPngBase64(bitmap)
         }
@@ -63,7 +64,7 @@ suspend fun getWatchScreenshotBytes(libPebble: LibPebble): ByteArray? {
         .filterIsInstance<ConnectedPebbleDevice>()
         .firstOrNull()
     if (watch is ConnectedPebble.Screenshot) {
-        val bitmap = watch.takeScreenshot() ?: return null
+        val bitmap = watch.takeScreenshot()?.toImageBitmap() ?: return null
         return imageBitmapToPngBytes(bitmap)
     }
     return null


### PR DESCRIPTION
Decouple the published API surface from Compose so external consumers don't need AndroidX/Compose, and tidy the surface for standalone consumption:

- Introduce image/PebbleBitmap.kt: a pure-Kotlin ARGB8888 bitmap. Replace ImageBitmap with PebbleBitmap in every published bitmap-returning API (Screenshot.takeScreenshot, NotificationApps.getAppIcon, Contacts.getContactImage) and all of their implementations. Add util conversion helpers (PebbleBitmap.toImageBitmap / Bitmap.toPebbleBitmap); app-side call sites convert at the point of rendering. Drop the @Stable Compose annotations from the interfaces.
- Extract the Contacts interface out of LibPebble.kt into its own contacts/Contacts.kt.
- Move FakeLibPebble from connection/ to a dedicated fake/ package and split the fake ConnectedPebbleDevice out into connection/FakeConnectedDevice.kt.