### PR TITLE
libpebble3: drop kable types from the public scan API

### DIFF
--- a/libindex/src/commonMain/kotlin/coredevices/libindex/device/RealScanning.kt
+++ b/libindex/src/commonMain/kotlin/coredevices/libindex/device/RealScanning.kt
@@ -46,7 +46,8 @@ class RealScanning(
                     identifier = it.identifier.asPebbleBleIdentifier(),
                     name = name,
                     rssi = it.rssi,
-                    manufacturerData = manufacturerData
+                    manufacturerCode = manufacturerData.code,
+                    manufacturerData = manufacturerData.data,
                 )
             }
     }

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/connection/Scanning.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/connection/Scanning.kt
@@ -1,7 +1,6 @@
 package io.rebble.libpebblecommon.connection
 
 import co.touchlab.kermit.Logger
-import com.juul.kable.ManufacturerData
 import com.oldguy.common.getShortAt
 import io.rebble.libpebblecommon.ErrorTracker
 import io.rebble.libpebblecommon.WatchConfigFlow
@@ -28,7 +27,8 @@ data class BleScanResult(
     val identifier: PebbleBleIdentifier,
     val name: String,
     val rssi: Int,
-    val manufacturerData: ManufacturerData,
+    val manufacturerCode: Int,
+    val manufacturerData: ByteArray,
 )
 
 data class PebbleScanResult(
@@ -82,10 +82,10 @@ class RealScanning(
             }
             try {
                 scanResults.collect {
-                    if (it.manufacturerData.code !in VENDOR_IDS) {
+                    if (it.manufacturerCode !in VENDOR_IDS) {
                         return@collect
                     }
-                    val pebbleScanRecord = it.manufacturerData.data.decodePebbleScanRecord()
+                    val pebbleScanRecord = it.manufacturerData.decodePebbleScanRecord()
                     if (shouldHideLegacyClassicWatch(pebbleScanRecord)) {
                         return@collect
                     }

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/connection/bt/ble/transport/impl/KableBleScanner.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/connection/bt/ble/transport/impl/KableBleScanner.kt
@@ -22,7 +22,8 @@ class KableBleScanner : BleScanner {
                     identifier = it.identifier.asPebbleBleIdentifier(),
                     name = name,
                     rssi = it.rssi,
-                    manufacturerData = manufacturerData
+                    manufacturerCode = manufacturerData.code,
+                    manufacturerData = manufacturerData.data,
                 )
             }
     }


### PR DESCRIPTION
BleScanResult exposed com.juul.kable.ManufacturerData, leaking kable (an `implementation` dependency) into the published common API surface. Replace it with plain manufacturerCode: Int + manufacturerData: ByteArray so the scan API has no kable type in its ABI; KableBleScanner decomposes the kable value at the boundary and RealScanning reads the split fields.