### PR TITLE
libpebble3: make internal implementation classes `internal`

### DIFF
--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/connection/LegacyBtClassicMigrator.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/connection/LegacyBtClassicMigrator.kt
@@ -16,7 +16,7 @@ import io.rebble.libpebblecommon.metadata.supportsBtClassic
  * Runs at app boot, gated by a Settings flag so it only executes once. Safe to call before
  * `BondedWatchSeeder` since either an existing row stays as-is (BLE) or gets re-keyed (Classic).
  */
-class LegacyBtClassicMigrator(
+internal class LegacyBtClassicMigrator(
     private val knownWatchDao: KnownWatchDao,
     private val settings: Settings,
     private val blePlatformConfig: BlePlatformConfig,

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/connection/PlatformIdentifier.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/connection/PlatformIdentifier.kt
@@ -4,7 +4,7 @@ import com.juul.kable.Peripheral
 import io.rebble.libpebblecommon.connection.bt.ble.transport.impl.peripheralFromIdentifier
 
 sealed class PlatformIdentifier {
-    class BlePlatformIdentifier(val peripheral: Peripheral) : PlatformIdentifier()
+    class BlePlatformIdentifier internal constructor(internal val peripheral: Peripheral) : PlatformIdentifier()
     class SocketPlatformIdentifier(val addr: String) : PlatformIdentifier()
     class BtClassicPlatformIdentifier(val identifier: PebbleBtClassicIdentifier) : PlatformIdentifier()
 }

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/connection/WatchManager.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/connection/WatchManager.kt
@@ -149,7 +149,7 @@ private data class CombinedState(
     val btstate: BluetoothState,
 )
 
-class WatchManager(
+class WatchManager internal constructor(
     private val knownWatchDao: KnownWatchDao,
     private val pebbleDeviceFactory: PebbleDeviceFactory,
     private val createPlatformIdentifier: CreatePlatformIdentifier,


### PR DESCRIPTION
Tighten the published ABI of the connection package by marking implementation-only classes `internal`, so they (and the kable Peripheral type they carry) don't appear in the public API of the standalone artifact:

- BlePlatformIdentifier: `internal` ctor + `internal val peripheral` (hides the com.juul.kable.Peripheral type).
- WatchManager: `internal` ctor.
- LegacyBtClassicMigrator: `internal` class.

All three are only constructed within libpebble3 (via DI), so this is ABI-only.