### PR TITLE
libpebble3: Defer BLE GATT server pre-registration until a BLE watch is paired

### DIFF
--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/connection/bt/ble/transport/GattServer.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/connection/bt/ble/transport/GattServer.kt
@@ -8,6 +8,8 @@ import io.rebble.libpebblecommon.connection.bt.BluetoothState
 import io.rebble.libpebblecommon.connection.bt.BluetoothStateProvider
 import io.rebble.libpebblecommon.connection.bt.ble.BlePlatformConfig
 import io.rebble.libpebblecommon.connection.bt.ble.pebble.SERVER_META_RESPONSE
+import io.rebble.libpebblecommon.database.dao.KnownWatchDao
+import io.rebble.libpebblecommon.database.entity.TransportType
 import io.rebble.libpebblecommon.di.LibPebbleCoroutineScope
 import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.flow.Flow
@@ -47,6 +49,7 @@ class GattServerManager(
     private val appContext: AppContext,
     private val bleConfigFlow: BleConfigFlow,
     private val blePlatformConfig: BlePlatformConfig,
+    private val knownWatchDao: KnownWatchDao,
 ) {
     private val serverMutex = Mutex()
     private val logger = Logger.withTag("GattServerManager")
@@ -57,7 +60,15 @@ class GattServerManager(
             bluetoothStateProvider.state.collect { bluetooth ->
                 logger.d("Bluetooth state: $bluetooth")
                 when (bluetooth) {
-                    BluetoothState.Enabled -> openIfNeeded()
+                    BluetoothState.Enabled -> {
+                        val hasBleWatch = knownWatchDao.knownWatches()
+                            .any { it.transportType == TransportType.BluetoothLe }
+                        if (hasBleWatch) {
+                            openIfNeeded()
+                        } else {
+                            logger.d("no BLE watches registered, skipping GATT server pre-registration")
+                        }
+                    }
                     BluetoothState.Disabled -> {
                         if (blePlatformConfig.closeGattServerWhenBtDisabled) {
                             close()
@@ -73,7 +84,7 @@ class GattServerManager(
         sendChannel: SendChannel<ByteArray>
     ): Boolean {
         if (gattServer == null && bluetoothStateProvider.state.value == BluetoothState.Enabled) {
-            logger.w("Trying to open gatt server to register device. This should only happen after bluetooth permission was just granted on android, during first use")
+            logger.w("Trying to open gatt server to register device. This happens on first pairing of a BLE watch, or after bluetooth permission is just granted.")
             openIfNeeded()
         }
         val gs = gattServer


### PR DESCRIPTION
## Description

This PR Changes the app to defer BLE GATT registration until after there is a registered pebble watch in the pebble app DB. Registration will already automatically happen as part of the pairing flow, so changing this lets both Gadgetbridge and the Pebble Mobileapp happily co-exist and the user is free to choose whichever app to use each wearable with. 

## Context
I noticed that I can't use Gadgetbridge for a BLE pebble watch, but the pebble mobile app for the Index ring simultaneously. I know this is may be an edge-case for most users, but it's impacting me.

I also saw the following review on Google play:

> When installing Pebble it forces me to uninstall another open hardware app (Gadgetbridge), which I use to connect my Casio watches. That's worse than what Casio, Amazfit and other smart device manufacturers are doing and I am shocked to see Pebble on track being evil like this.

The only conflict (that I can find) between the Pebble Mobile app and Gadgetbridge is the Pebble GATT registration of the same UUID for pebble BLE watches. Gadgetbridge registers this UUID lazily (when a Pebble watch is paired and set to auto-connect), but the pebble app _always_ registers this even if there isn't a paired watch.

## Test-Plan
Launched debug version of app
Paired pebble watch with GB
Removed all pebble watches from Pebble mobile app
Paired Index with Pebble mobile app
Verified index functionality
Verified GB could connect to the pebble watch

Removed pebble watch from GB
Paired pebble watch with pebble mobile app
Verified watch functioned normally
Verified I could force-close and re-open pebble mobile app
Pebble mobile-app auto-connected to the pebble watch as expected