### PR TITLE
Android: trust user-installed CA certs via Network Security Config

### DIFF
--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -16,6 +16,7 @@
     <application
         android:name=".MainApplication"
         android:usesCleartextTraffic="true"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/composeApp/src/androidMain/res/xml/network_security_config.xml
+++ b/composeApp/src/androidMain/res/xml/network_security_config.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Allow user-installed CA certificates to be trusted in addition to the system
+  CA store. Since Android 7.0 (API 24), apps only trust the system store by
+  default, so PKJS apps connecting to self-hosted servers with a self-signed or
+  private-CA cert (e.g. Home Assistant over wss://) fail to connect even after
+  the user installs and trusts the cert on their device.
+-->
+<network-security-config>
+    <base-config>
+        <trust-anchors>
+            <certificates src="system" />
+            <certificates src="user" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>


### PR DESCRIPTION
## Problem

On Android, PKJS apps that open `https`/`wss` connections to a server using a self-signed or private-CA cert fail to connect, even after the user installs and trusts that cert on their device.

Since Android 7.0 (API 24), apps only trust the **system** CA store by default. The app targets `targetSdk = 35` and ships no Network Security Config, so the WebView that runs PKJS (and its WebSocket connections) ignores the **user** CA store. The cert is trusted by the device but ignored by the app, and there's nothing the user can do on-device to fix it.

This came up with a Home Assistant PKJS app where users self-host with self-signed certs. The WebSocket fails the TLS handshake and closes immediately (abnormal close, 1006).

## Fix

Add a Network Security Config that trusts the user store alongside the system store, and reference it from the manifest's `<application>` tag.

`composeApp/src/androidMain/res/xml/network_security_config.xml`:
```xml
<network-security-config>
    <base-config>
        <trust-anchors>
            <certificates src="system" />
            <certificates src="user" />
        </trust-anchors>
    </base-config>
</network-security-config>
```

Manifest:
```xml
android:networkSecurityConfig="@xml/network_security_config"
```

iOS already honors user-trusted roots (NSURLSession, once "Full Trust" is enabled), so this brings Android in line.

## Notes

- Closes #247
