### PR TITLE
Fix LAN dev-connection server leaking port 9000 on stop/reconnect

### DIFF
--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/connection/devconnection/DevConnectionLANServer.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/connection/devconnection/DevConnectionLANServer.kt
@@ -25,14 +25,12 @@ import io.rebble.libpebblecommon.structmapper.SFixedString
 import io.rebble.libpebblecommon.structmapper.SUByte
 import io.rebble.libpebblecommon.structmapper.SUInt
 import io.rebble.libpebblecommon.structmapper.StructMappable
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.NonCancellable
-import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.isActive
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -138,37 +136,32 @@ class DevConnectionServer(libPebble: LibPebble): DevConnectionTransport(libPebbl
                 }
             }
         }
-        while (currentCoroutineContext().isActive) {
-            val newServer = embeddedServer(CIO, rootConfig) {
-                connectors.add(EngineConnectorBuilder().apply {
-                    host = "0.0.0.0"
-                    port = PORT
-                })
-                connectionGroupSize = 1
-                workerGroupSize = 2
-                callGroupSize = 2
-            }
-            // Assign before starting so stop() can always reach the server,
-            // even if startSuspend() is cancelled by collectLatest.
-            server = newServer
-            try {
-                newServer.startSuspend()
-                logger.w { "Dev connection server exited unexpectedly, restarting on port $PORT" }
-            } catch (e: CancellationException) {
-                withContext(NonCancellable) { newServer.stopSuspend() }
-                throw e
-            } catch (e: Exception) {
-                logger.e(e) { "Dev connection server crashed, restarting on port $PORT" }
-                newServer.stopSuspend()
-            }
-            delay(1000)
+        // startSuspend() returns immediately in this engine config; looping on it would spawn a
+        // duplicate server that fails to bind. Start once and suspend until stop()/cancellation.
+        val newServer = embeddedServer(CIO, rootConfig) {
+            connectors.add(EngineConnectorBuilder().apply {
+                host = "0.0.0.0"
+                port = PORT
+            })
+            connectionGroupSize = 1
+            workerGroupSize = 2
+            callGroupSize = 2
         }
+        server = newServer
+        newServer.start()
+        logger.i { "Dev connection server listening on port $PORT" }
+        awaitCancellation()
     }
 
     override suspend fun stop() {
-        server?.stopSuspend()
+        val toStop = server
         server = null
-        logger.i { "Server stopped" }
+        if (toStop != null) {
+            withContext(NonCancellable) {
+                toStop.stopSuspend()
+            }
+            logger.i { "Server stopped" }
+        }
     }
 }
 

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/connection/devconnection/DevConnectionManager.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/connection/devconnection/DevConnectionManager.kt
@@ -37,16 +37,24 @@ class DevConnectionManager(
         val inboundPKJSLogs = companionAppLifecycleManager.currentPKJSSession.flatMapLatest { it?.logMessages?.receiveAsFlow() ?: emptyFlow() }
         job.value = scope.launch {
             var last: DevConnectionTransport? = null
-            transport.onCompletion {
-                last?.stop()
-            }.collectLatest {
-                last?.stop()
-                it.start(identifier, inboundPKJSLogs, protocolHandler.rawInboundMessages) { message ->
-                    protocolHandler.send(
-                        message
-                    )
+            try {
+                transport.onCompletion {
+                    last?.stop()
+                }.collectLatest {
+                    last?.stop()
+                    // Assign before start(): start() suspends until cancelled, so the finally
+                    // below would otherwise always see `last` as null.
+                    last = it
+                    it.start(identifier, inboundPKJSLogs, protocolHandler.rawInboundMessages) { message ->
+                        protocolHandler.send(
+                            message
+                        )
+                    }
                 }
-                last = it
+            } finally {
+                // The LAN server is a process-wide singleton; coroutine cancellation alone won't
+                // release its socket, so stop() explicitly to free port 9000.
+                last?.stop()
             }
         }.apply {
             invokeOnCompletion {


### PR DESCRIPTION
The LAN dev-connection server (port 9000) was never released when dev connection was toggled off or the watch disconnected, and could not rebind on reconnect -- requiring an app force-stop to recover.

startSuspend() returns immediately in this Ktor/CIO engine config, so the restart loop spawned a duplicate server that failed to bind while the real listener leaked unreferenced. stop() then operated on the wrong instance, so the socket was never freed. Additionally, the transport was assigned to `last` only after start() returns, but start() now suspends indefinitely, so the stop() in teardown always saw null.

Start the server once and await cancellation; record the transport before start(); and explicitly stop() in a finally to free the port on toggle-off and disconnect.

Fixes #219

Co-Authored-By: glm-5.2


## Reproduction steps for the issue:
1. Enable Settings -> Phone -> Connectivity -> Use LAN developer connection
2. On a device, enable Dev Connection
3. Using pebble tools, run `pebble ping --phone <IP>` (works)
4. Turn off Dev Connection
5. Run the ping command again and note that it still works, even though the connection should be off
6. Disconnect the phone either with the Disconnect button, or by toggling Bluetooth on the watch
7. Reconnect the watch
8. Turn on Dev Connection
9. Run the ping command again (fails)