### PR TITLE
Add option to disable speech recognition

### DIFF
--- a/composeApp/src/commonMain/kotlin/coredevices/coreapp/ui/screens/BugReportProcessor.kt
+++ b/composeApp/src/commonMain/kotlin/coredevices/coreapp/ui/screens/BugReportProcessor.kt
@@ -150,6 +150,7 @@ class BugReportProcessor(
                 CactusSTTMode.LocalOnly, CactusSTTMode.LocalFirst -> "Local"
                 CactusSTTMode.RemoteOnly, CactusSTTMode.RemoteFirst -> "Remote"
                 CactusSTTMode.RebbleOnly, CactusSTTMode.RebbleFirst, CactusSTTMode.RebbleFallback -> "Rebble"
+                CactusSTTMode.Disabled -> "Disabled"
                 null -> "None"
             }
             "\nSTT Summary\n" +

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/services/STTRouter.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/services/STTRouter.kt
@@ -43,6 +43,7 @@ class STTRouter(
     override suspend fun canServeSession(): Boolean {
         val mode = coreConfigFlow.value.sttConfig.mode
         return when (mode) {
+            CactusSTTMode.Disabled -> false
             CactusSTTMode.RebbleOnly -> rebble.isAvailable()
             CactusSTTMode.RebbleFirst, CactusSTTMode.RebbleFallback ->
                 rebble.isAvailable() || cactus.canServeSession()

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchSettingsScreen.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchSettingsScreen.kt
@@ -1376,7 +1376,13 @@ fun rememberSettingsItemsState(navBarNav: NavBarNav?, snackbarDisplay: SnackbarD
                                 it == CactusSTTMode.LocalFirst ||
                                 it == CactusSTTMode.RebbleFirst ||
                                 it == CactusSTTMode.RebbleFallback
-                        if (isRebble && !rebbleVoiceAvailable) {
+                        if (it == CactusSTTMode.Disabled) {
+                            coreConfigHolder.update(
+                                coreConfig.copy(
+                                    sttConfig = coreConfig.sttConfig.copy(mode = it)
+                                )
+                            )
+                        } else if (isRebble && !rebbleVoiceAvailable) {
                             snackbarDisplay.showSnackbar("Rebble speech recognition requires a Rebble subscription")
                             showSignInDialog = true
                         } else if (it != CactusSTTMode.RemoteOnly && !cactusSupported) {
@@ -1405,6 +1411,7 @@ fun rememberSettingsItemsState(navBarNav: NavBarNav?, snackbarDisplay: SnackbarD
                             CactusSTTMode.RebbleOnly -> "Rebble Only"
                             CactusSTTMode.RebbleFirst -> "Rebble (with Local Fallback)"
                             CactusSTTMode.RebbleFallback -> "Local (with Rebble Fallback)"
+                            CactusSTTMode.Disabled -> "Disabled"
                         }
                     },
                     extraSupportingContent = {

--- a/util/src/commonMain/kotlin/coredevices/util/models/Cactus.kt
+++ b/util/src/commonMain/kotlin/coredevices/util/models/Cactus.kt
@@ -7,7 +7,8 @@ enum class CactusSTTMode(val id: Int) {
     LocalFirst(3),
     RebbleOnly(4),
     RebbleFirst(5),
-    RebbleFallback(6);
+    RebbleFallback(6),
+    Disabled(7);
 
     companion object {
         fun fromId(id: Int): CactusSTTMode {

--- a/util/src/commonMain/kotlin/coredevices/util/transcription/HybridTranscriptionService.kt
+++ b/util/src/commonMain/kotlin/coredevices/util/transcription/HybridTranscriptionService.kt
@@ -74,6 +74,7 @@ class HybridTranscriptionService(
             CactusSTTMode.RebbleOnly,
             CactusSTTMode.RebbleFirst,
             CactusSTTMode.RebbleFallback -> false
+            CactusSTTMode.Disabled -> false
         }
     }
 
@@ -238,6 +239,8 @@ class HybridTranscriptionService(
             CactusSTTMode.RebbleFirst,
             CactusSTTMode.RebbleFallback ->
                 error("Rebble mode $sttMode should be handled by STTRouter, not HybridTranscriptionService")
+            CactusSTTMode.Disabled ->
+                error("Disabled mode should not reach HybridTranscriptionService")
         }
     }
 


### PR DESCRIPTION
Closes #269

## Problem

Speech recognition offers a choice between the cloud model and the ~670MB on-device model, but no way to turn it off. A user who wants neither is stuck: selecting Cloud prompts a sign in, and the only way to opt out is to download the local model and then delete it, which reverts to Cloud.

## Change

Adds a Disabled speech recognition mode. Selecting it in Settings under Offline Speech Recognition turns transcription off with no sign in and no model download.

When the mode is Disabled, STTRouter.canServeSession() returns false, so VoiceSessionManager replies to the watch with the existing FailDisabled result. That is the same path used today when speech recognition is unavailable, so there is no new on-device behaviour.

## Notes

Selection, routing, and the bug report summary already switch on sttConfig.mode, so the change is a new enum value plus the branches that handle it. The mode is serialized by name, so existing configs are unaffected.

Claude helped put this PR together.
