### PR TITLE
Clarify that the spoken-language setting only affects cloud STT

### DIFF
--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchSettingsScreen.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchSettingsScreen.kt
@@ -1448,16 +1448,6 @@ fun rememberSettingsItemsState(navBarNav: NavBarNav?, snackbarDisplay: SnackbarD
                         nav.navigateTo(PebbleNavBarRoutes.OfflineModelsRoute)
                     },
                 ) },
-                basicSettingsActionItem(
-                    title = "Spoken Language",
-                    description = coreConfig.sttConfig.spokenLanguage
-                        ?.let { code -> SpokenLanguageOptions.firstOrNull { it.first == code }?.second ?: code }
-                        ?: "Automatic",
-                    keywords = "language stt speech recognition locale iso",
-                    topLevelType = TopLevelType.Phone,
-                    section = Section.Speech,
-                    action = { showSpokenLanguageDialog = true },
-                ),
                 SettingsItem(
                     title = "Cloud Recognition Provider",
                     isDebugSetting = false,
@@ -1482,6 +1472,18 @@ fun rememberSettingsItemsState(navBarNav: NavBarNav?, snackbarDisplay: SnackbarD
                             shadowElevation = ELEVATION,
                         )
                     }
+                ),
+                basicSettingsActionItem(
+                    title = "Cloud Spoken Language",
+                    description = "${
+                        coreConfig.sttConfig.spokenLanguage
+                            ?.let { code -> SpokenLanguageOptions.firstOrNull { it.first == code }?.second ?: code }
+                            ?: "Automatic"
+                    }. Only used for cloud transcription; the on-device model detects language automatically.",
+                    keywords = "language stt speech recognition locale iso cloud wispr provider",
+                    topLevelType = TopLevelType.Phone,
+                    section = Section.Speech,
+                    action = { showSpokenLanguageDialog = true },
                 ),
                 basicSettingsToggleItem(
                     title = "Ignore other Pebble apps",
@@ -2613,7 +2615,7 @@ fun SpokenLanguagePickerDialog(
     M3Dialog(
         onDismissRequest = onDismissRequest,
         icon = { Icon(Icons.Default.Language, contentDescription = null) },
-        title = { Text("Spoken Language") },
+        title = { Text("Cloud Spoken Language") },
         buttons = {
             TextButton(onClick = onDismissRequest) { Text("Cancel") }
         },
@@ -2647,7 +2649,7 @@ fun SpokenLanguagePickerDialog(
             }
             Spacer(Modifier.height(8.dp))
             Text(
-                "Note: Selecting a language may improve accuracy for that language but not all languages on this list are guaranteed to be supported.",
+                "This language is only used for cloud transcription. On-device (local) transcription always detects the language automatically and ignores this setting. Choosing a language may improve cloud accuracy, though not every language listed is guaranteed to be supported.",
                 fontSize = 11.sp,
             )
         }


### PR DESCRIPTION
The spoken-language setting currently reads as though it might also affect on-device transcription. In practice the selection is only sent to the cloud providers (WisprFlow and Kirinki); the local Cactus model does not use it. This PR updates the UI to reflect that. There is no behavior change.

Changes:
- Renamed the Watch Settings item and its picker dialog to "Cloud Spoken Language".
- Moved it directly under "Cloud Recognition Provider" so it sits within the cloud section.
- Added the current selection plus a note in the subtitle that the on-device model detects language automatically.
- Updated the dialog note to state that on-device transcription is not affected by this setting.

For reference, the routing: `HybridTranscriptionService.route()` forwards `language` only to the remote path. `transcribeLocal` and `transcribeLocalForFallback` take no language, and the native `cactusTranscribe` call passes null for prompt and options. The Rebble local fallback in `STTRouter` is the same.

One file, copy and layout only: `pebble/.../ui/WatchSettingsScreen.kt`.

Claude helped put this PR together.
