### PR TITLE
Add selectable on-device STT model with an English option (parakeet tdt 0.6b v2)

### DIFF
--- a/composeApp/src/androidInstrumentedTest/kotlin/coredevices/coreapp/transcription/CactusLocalCancellationTest.kt
+++ b/composeApp/src/androidInstrumentedTest/kotlin/coredevices/coreapp/transcription/CactusLocalCancellationTest.kt
@@ -89,7 +89,7 @@ class CactusLocalCancellationTest {
                     println("[cactus-cancel] model missing at ${modelDir.absolutePath} — downloading $MODEL_NAME (one-time, hundreds of MB)…")
                     // Only the *production* provider downloads; its delete-then-download is harmless
                     // when there's no valid model to lose.
-                    runBlocking { withTimeout(20.minutes) { CactusModelProvider().getSTTModelPath() } }
+                    runBlocking { withTimeout(20.minutes) { CactusModelProvider().getSTTModelPath(MODEL_NAME) } }
                 }
                 modelPresent = provider.isModelDownloaded(MODEL_NAME)
                 println("[cactus-cancel] model dir=${modelDir.absolutePath} present=$modelPresent")
@@ -227,7 +227,7 @@ class CactusLocalCancellationTest {
      * never downloads or deletes, so running the tests can't wipe the on-device model.
      */
     private class ReadOnlyModelPathProvider(private val modelsDir: File) : CactusModelPathProvider {
-        override suspend fun getSTTModelPath(): String = modelsDir.resolve(MODEL_NAME).absolutePath
+        override suspend fun getSTTModelPath(modelSlug: String): String = modelsDir.resolve(modelSlug).absolutePath
         override suspend fun getLMModelPath(): String = error("LM model not used in this test")
         override fun isModelDownloaded(modelName: String): Boolean =
             modelsDir.resolve(modelName).resolve("config.txt").exists()

--- a/composeApp/src/commonMain/kotlin/coredevices/coreapp/di/utilModule.kt
+++ b/composeApp/src/commonMain/kotlin/coredevices/coreapp/di/utilModule.kt
@@ -90,7 +90,7 @@ val utilModule = module {
         CactusTranscriptionService(
             get(),
             getOrNull<CactusModelPathProvider>() ?: object : CactusModelPathProvider {
-                override suspend fun getSTTModelPath(): String = throw IllegalStateException("CactusModelPathProvider not available")
+                override suspend fun getSTTModelPath(modelSlug: String): String = throw IllegalStateException("CactusModelPathProvider not available")
                 override suspend fun getLMModelPath(): String = throw IllegalStateException("CactusModelPathProvider not available")
                 override fun isModelDownloaded(modelName: String): Boolean = false
                 override fun getDownloadedModels(): List<String> = emptyList()

--- a/experimental/src/androidMain/kotlin/coredevices/ring/model/CactusModelProvider.android.kt
+++ b/experimental/src/androidMain/kotlin/coredevices/ring/model/CactusModelProvider.android.kt
@@ -4,6 +4,9 @@ import android.content.Context
 import co.touchlab.kermit.Logger
 import com.cactus.cactusSetTelemetryEnvironment
 import coredevices.util.CommonBuildKonfig
+import coredevices.util.models.ModelDownloadManager
+import coredevices.util.models.ModelDownloadStatus
+import coredevices.util.models.SttModelCatalog
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import org.koin.mp.KoinPlatform
@@ -39,9 +42,8 @@ actual class CactusModelProvider actual constructor() : coredevices.util.transcr
     private val context: Context get() = KoinPlatform.getKoin().get()
     private val modelsDir: File get() = context.filesDir.resolve("models").also { it.mkdirs() }
 
-    actual override suspend fun getSTTModelPath(): String = withContext(Dispatchers.IO) {
-        val modelName = CommonBuildKonfig.CACTUS_STT_MODEL
-        return@withContext resolveModelPath(modelName, CommonBuildKonfig.CACTUS_STT_WEIGHTS_VERSION)
+    actual override suspend fun getSTTModelPath(modelSlug: String): String = withContext(Dispatchers.IO) {
+        return@withContext resolveModelPath(modelSlug, SttModelCatalog.versionFor(modelSlug))
     }
 
     actual override suspend fun getLMModelPath(): String = withContext(Dispatchers.IO) {
@@ -113,6 +115,11 @@ actual class CactusModelProvider actual constructor() : coredevices.util.transcr
             val url = "$HF_BASE/$modelName/resolve/$version/weights/$zipName"
             logger.i { "Downloading model: $url" }
 
+            // Surface byte-level progress to the shared download status so the UI can show a
+            // real percentage (the JobService itself only knows start/end). Optional: absent
+            // in contexts without the manager (e.g. tests), in which case we just don't report.
+            val downloadManager = runCatching { KoinPlatform.getKoin().get<ModelDownloadManager>() }.getOrNull()
+
             val tempZip = File(context.cacheDir, "cactus_download_$modelName.zip")
             // Cancel the in-flight HTTP call if the coroutine is cancelled so a blocked
             // socket read unblocks promptly instead of hanging until readTimeout.
@@ -138,6 +145,7 @@ actual class CactusModelProvider actual constructor() : coredevices.util.transcr
                     val totalBytes = body.contentLength()
                     var downloadedBytes = 0L
                     var lastLoggedPct = -1
+                    var lastReportedPct = -1
 
                     body.byteStream().use { input ->
                         FileOutputStream(tempZip).use { output ->
@@ -152,6 +160,12 @@ actual class CactusModelProvider actual constructor() : coredevices.util.transcr
                                     if (pct / 10 > lastLoggedPct / 10) {
                                         lastLoggedPct = pct
                                         logger.d { "Download progress: $pct% ($downloadedBytes / $totalBytes)" }
+                                    }
+                                    if (pct != lastReportedPct) {
+                                        lastReportedPct = pct
+                                        downloadManager?.updateDownloadStatus(
+                                            ModelDownloadStatus.Downloading(modelName, pct / 100f)
+                                        )
                                     }
                                 }
                             }

--- a/experimental/src/commonMain/kotlin/coredevices/ring/model/CactusModelProvider.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/model/CactusModelProvider.kt
@@ -12,7 +12,7 @@ import coredevices.util.transcription.CactusModelPathProvider
  * Each model directory contains config.txt, vocab.txt, and .weights files.
  */
 expect class CactusModelProvider() : CactusModelPathProvider {
-    override suspend fun getSTTModelPath(): String
+    override suspend fun getSTTModelPath(modelSlug: String): String
     override suspend fun getLMModelPath(): String
     override fun isModelDownloaded(modelName: String): Boolean
     override fun getDownloadedModels(): List<String>

--- a/experimental/src/iosMain/kotlin/coredevices/ring/model/CactusModelProvider.ios.kt
+++ b/experimental/src/iosMain/kotlin/coredevices/ring/model/CactusModelProvider.ios.kt
@@ -3,6 +3,7 @@ package coredevices.ring.model
 import co.touchlab.kermit.Logger
 import com.cactus.cactusSetTelemetryEnvironment
 import coredevices.util.CommonBuildKonfig
+import coredevices.util.models.SttModelCatalog
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.io.buffered
@@ -40,9 +41,8 @@ actual class CactusModelProvider actual constructor() : coredevices.util.transcr
 
     private val modelsDir: String get() = "$cachesDir/models"
 
-    actual override suspend fun getSTTModelPath(): String {
-        val modelName = CommonBuildKonfig.CACTUS_STT_MODEL
-        return resolveModelPath(modelName, CommonBuildKonfig.CACTUS_STT_WEIGHTS_VERSION)
+    actual override suspend fun getSTTModelPath(modelSlug: String): String {
+        return resolveModelPath(modelSlug, SttModelCatalog.versionFor(modelSlug))
     }
 
     actual override suspend fun getLMModelPath(): String {
@@ -64,7 +64,7 @@ actual class CactusModelProvider actual constructor() : coredevices.util.transcr
     }
 
     actual override fun getIncompatibleModels(): List<String> {
-        val compatible = setOf(CommonBuildKonfig.CACTUS_STT_MODEL, CommonBuildKonfig.CACTUS_LM_MODEL_NAME)
+        val compatible = SttModelCatalog.models.map { it.slug }.toSet() + CommonBuildKonfig.CACTUS_LM_MODEL_NAME
         return getDownloadedModels().filter { it !in compatible }
     }
 

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/ModelManagementScreen.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/ModelManagementScreen.kt
@@ -56,6 +56,7 @@ import coredevices.util.models.ModelDownloadStatus
 import coredevices.util.models.ModelInfo
 import coredevices.util.models.ModelManager
 import coredevices.util.models.RecommendedModel
+import coredevices.util.models.SttModelCatalog
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -94,13 +95,15 @@ class ModelManagementScreenViewModel(
         }
     }
 
-    val currentSTTModel = coreConfigHolder.config.map { it.sttConfig.modelName }.onEach {
-        Logger.d("Current STT model changed to $it")
-    }.stateIn(
-        viewModelScope,
-        started = kotlinx.coroutines.flow.SharingStarted.Lazily,
-        initialValue = coreConfigHolder.config.value.sttConfig.modelName
-    )
+    val currentSTTModel = coreConfigHolder.config
+        .map { it.sttConfig.modelName ?: SttModelCatalog.defaultSlug }
+        .onEach {
+            Logger.d("Current STT model changed to $it")
+        }.stateIn(
+            viewModelScope,
+            started = kotlinx.coroutines.flow.SharingStarted.Lazily,
+            initialValue = coreConfigHolder.config.value.sttConfig.modelName ?: SttModelCatalog.defaultSlug
+        )
 
     sealed interface AvailableModelsState {
         object Loading : AvailableModelsState
@@ -180,11 +183,13 @@ class ModelManagementScreenViewModel(
         viewModelScope.launch {
             _availableSTTModels.value = try {
                 val models = modelManager.getAvailableSTTModels()
-                val recommendedSTTModelSlug = modelManager.getRecommendedSTTModel()
+                val catalogSlugs = SttModelCatalog.models.map { it.slug }.toSet()
                 AvailableModelsState.Success(
                     if (!settings.showDebugOptions()) {
+                        // Always surface the catalog models (both parakeets); keep
+                        // hiding legacy models unless they're already on disk.
                         models.filter {
-                            it.slug == recommendedSTTModelSlug.modelSlug || it.slug in downloadedModels.value
+                            it.slug in catalogSlugs || it.slug in downloadedModels.value
                         }
                     } else {
                         models
@@ -218,6 +223,7 @@ fun ModelDownloadPromptDialog(
     downloadSizeInMb: Int,
     onGetRecommended: () -> Unit,
     onDismiss: () -> Unit,
+    onChooseModel: (() -> Unit)? = null,
 ) {
     M3Dialog(
         onDismissRequest = onDismiss,
@@ -237,7 +243,14 @@ fun ModelDownloadPromptDialog(
                 if (isLite) {
                     Text("Download lite model: ${downloadSizeInMb}MB")
                 } else {
-                    Text("Download offline model: ${downloadSizeInMb}MB")
+                    Text("Download recommended: ${downloadSizeInMb}MB")
+                }
+            }
+            if (onChooseModel != null) {
+                TextButton(
+                    onClick = onChooseModel,
+                ) {
+                    Text("Choose a different model")
                 }
             }
             TextButton(
@@ -378,6 +391,7 @@ private fun ModelListItem(
     onDelete: () -> Unit,
     onSelect: () -> Unit,
 ) {
+    val spec = SttModelCatalog.forSlug(model.slug)
     ListItem(
         modifier = modifier
             .fillMaxWidth()
@@ -385,8 +399,10 @@ private fun ModelListItem(
                 onSelect()
             },
         overlineContent = { if (isRecommended) { Text("Recommended for your device") } },
-        headlineContent = { Text(model.slug) },
-        supportingContent = { Text("${model.sizeInMB} MB") },
+        headlineContent = { Text(spec?.displayName ?: model.slug) },
+        supportingContent = {
+            Text(spec?.let { "${it.description} · ${model.sizeInMB} MB" } ?: "${model.sizeInMB} MB")
+        },
         leadingContent = {
             RadioButton(
                 selected = isSelected && downloadState == DownloadState.Downloaded,

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchSettingsScreen.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchSettingsScreen.kt
@@ -407,6 +407,19 @@ fun rememberSettingsItemsState(navBarNav: NavBarNav?, snackbarDisplay: SnackbarD
                     pendingSTTModeDialog = null
                 }
             },
+            onChooseModel = navBarNav?.let { nav ->
+                {
+                    // Switch to the chosen local mode and let the user pick/download
+                    // a specific model instead of being forced onto the recommended one.
+                    coreConfigHolder.update(
+                        coreConfig.copy(
+                            sttConfig = coreConfig.sttConfig.copy(mode = pendingSTTMode)
+                        )
+                    )
+                    pendingSTTModeDialog = null
+                    nav.navigateTo(PebbleNavBarRoutes.OfflineModelsRoute)
+                }
+            },
             onDismiss = {
                 pendingSTTModeDialog = null
             }

--- a/util/src/androidMain/kotlin/coredevices/util/models/ModelDownloadManager.android.kt
+++ b/util/src/androidMain/kotlin/coredevices/util/models/ModelDownloadManager.android.kt
@@ -313,7 +313,7 @@ class ModelDownloadService : JobService(), KoinComponent {
     private suspend fun downloadModel(modelSlug: String, stt: Boolean) {
         val modelProvider: CactusModelPathProvider by inject()
         if (stt) {
-            modelProvider.getSTTModelPath()
+            modelProvider.getSTTModelPath(modelSlug)
         } else {
             modelProvider.getLMModelPath()
         }

--- a/util/src/commonMain/kotlin/coredevices/ui/ModelDownloadDialog.kt
+++ b/util/src/commonMain/kotlin/coredevices/ui/ModelDownloadDialog.kt
@@ -53,7 +53,7 @@ fun ModelDownloadDialog(
             try {
                 models.forEach { model ->
                     when (model) {
-                        is ModelType.STT -> modelProvider.getSTTModelPath()
+                        is ModelType.STT -> modelProvider.getSTTModelPath(model.modelName)
                         is ModelType.Agent -> modelProvider.getLMModelPath()
                     }
                 }

--- a/util/src/commonMain/kotlin/coredevices/util/models/ModelManager.kt
+++ b/util/src/commonMain/kotlin/coredevices/util/models/ModelManager.kt
@@ -38,29 +38,28 @@ class ModelManager(
     }
 
     suspend fun getAvailableSTTModels(): List<ModelInfo> {
-        val sttModel = CommonBuildKonfig.CACTUS_STT_MODEL
-        val sttVersion = CommonBuildKonfig.CACTUS_STT_WEIGHTS_VERSION
-        val sttSizeMB = modelPathProvider?.let {
-            val onDisk = (it.getModelSizeBytes(sttModel) / (1024 * 1024)).toInt()
-            if (onDisk > 0) onDisk else KNOWN_STT_SIZE_MB
-        } ?: KNOWN_STT_SIZE_MB
-
-        val currentModel = ModelInfo(
-            slug = sttModel,
-            sizeInMB = sttSizeMB,
-            url = "$HF_BASE/$sttModel/resolve/$sttVersion/weights/${sttModel.lowercase()}-$STT_QUANTIZATION.zip"
-        )
+        val catalogModels = SttModelCatalog.models.map { spec ->
+            val onDisk = modelPathProvider?.let {
+                (it.getModelSizeBytes(spec.slug) / (1024 * 1024)).toInt()
+            } ?: 0
+            ModelInfo(
+                slug = spec.slug,
+                sizeInMB = if (onDisk > 0) onDisk else spec.sizeInMB,
+                url = SttModelCatalog.downloadUrl(spec.slug),
+            )
+        }
 
         // Include old downloaded models (e.g. whisper) so they can be deleted
+        val knownSlugs = SttModelCatalog.models.map { it.slug }.toSet()
         val lmModel = CommonBuildKonfig.CACTUS_LM_MODEL_NAME
         val oldModels = modelPathProvider?.getDownloadedModels()
-            ?.filter { it != sttModel && it != lmModel }
+            ?.filter { it !in knownSlugs && it != lmModel }
             ?.map { slug ->
                 val sizeMB = (modelPathProvider.getModelSizeBytes(slug) / (1024 * 1024)).toInt()
                 ModelInfo(slug = slug, sizeInMB = sizeMB)
             } ?: emptyList()
 
-        return listOf(currentModel) + oldModels
+        return catalogModels + oldModels
     }
 
     suspend fun getAvailableLanguageModels(): List<ModelInfo> {
@@ -80,9 +79,7 @@ class ModelManager(
 
     companion object {
         private const val HF_BASE = "https://huggingface.co/Cactus-Compute"
-        private const val STT_QUANTIZATION = "int8"
         private const val LM_QUANTIZATION = "int4"
-        private const val KNOWN_STT_SIZE_MB = 670
         private const val KNOWN_LM_SIZE_MB = 530
     }
 

--- a/util/src/commonMain/kotlin/coredevices/util/models/SttModelCatalog.kt
+++ b/util/src/commonMain/kotlin/coredevices/util/models/SttModelCatalog.kt
@@ -1,0 +1,71 @@
+package coredevices.util.models
+
+import coredevices.util.CommonBuildKonfig
+
+/**
+ * A speech-to-text model the app can download and select between.
+ *
+ * [version] is the Cactus packaging/format tag on the model's Hugging Face repo
+ * (e.g. "v1.10") and must be one the bundled Cactus runtime understands, so all
+ * STT models are pinned to the same format version as the default model.
+ */
+data class SttModelSpec(
+    val slug: String,
+    val version: String,
+    val quantization: String,
+    val sizeInMB: Int,
+    val displayName: String,
+    val description: String,
+    val englishOnly: Boolean,
+)
+
+/**
+ * The set of STT models the app exposes for selection. Replaces the previous
+ * reliance on the single [CommonBuildKonfig.CACTUS_STT_MODEL] build constant for
+ * everything except the *default* model.
+ */
+object SttModelCatalog {
+    private const val HF_BASE = "https://huggingface.co/Cactus-Compute"
+
+    val models: List<SttModelSpec> = listOf(
+        // Default / recommended. Version is driven by the build config so the two
+        // can't drift apart.
+        SttModelSpec(
+            slug = CommonBuildKonfig.CACTUS_STT_MODEL,
+            version = CommonBuildKonfig.CACTUS_STT_WEIGHTS_VERSION,
+            quantization = "int8",
+            sizeInMB = 670,
+            displayName = "Parakeet 0.6B",
+            description = "Multilingual · 25 languages",
+            englishOnly = false,
+        ),
+        // English-only opt-in. Same architecture and footprint as the default
+        // (parakeet-tdt-0.6b), materially better English accuracy on noisy or
+        // hard speech. Pinned to the same weights format version as the default.
+        SttModelSpec(
+            slug = "parakeet-tdt-0.6b-v2",
+            version = "v1.10",
+            quantization = "int8",
+            sizeInMB = 670,
+            displayName = "Parakeet 0.6B (English)",
+            description = "English only · best English accuracy",
+            englishOnly = true,
+        ),
+    )
+
+    /** The model loaded when the user has not explicitly chosen one. */
+    val defaultSlug: String get() = CommonBuildKonfig.CACTUS_STT_MODEL
+
+    fun forSlug(slug: String): SttModelSpec? = models.firstOrNull { it.slug == slug }
+
+    /** Falls back to the default STT weights version for unknown slugs (e.g. legacy models). */
+    fun versionFor(slug: String): String =
+        forSlug(slug)?.version ?: CommonBuildKonfig.CACTUS_STT_WEIGHTS_VERSION
+
+    fun downloadUrl(slug: String): String {
+        val spec = forSlug(slug)
+        val version = spec?.version ?: CommonBuildKonfig.CACTUS_STT_WEIGHTS_VERSION
+        val quant = spec?.quantization ?: "int8"
+        return "$HF_BASE/$slug/resolve/$version/weights/${slug.lowercase()}-$quant.zip"
+    }
+}

--- a/util/src/commonMain/kotlin/coredevices/util/transcription/CactusModelPathProvider.kt
+++ b/util/src/commonMain/kotlin/coredevices/util/transcription/CactusModelPathProvider.kt
@@ -1,7 +1,8 @@
 package coredevices.util.transcription
 
 interface CactusModelPathProvider {
-    suspend fun getSTTModelPath(): String
+    /** Resolves (downloading if needed) the on-disk path for the given STT model slug. */
+    suspend fun getSTTModelPath(modelSlug: String): String
     suspend fun getLMModelPath(): String
     fun isModelDownloaded(modelName: String): Boolean
     fun getDownloadedModels(): List<String>

--- a/util/src/commonMain/kotlin/coredevices/util/transcription/CactusTranscriptionService.kt
+++ b/util/src/commonMain/kotlin/coredevices/util/transcription/CactusTranscriptionService.kt
@@ -8,9 +8,9 @@ import com.cactus.cactusStop
 import com.cactus.cactusTranscribe
 import com.cactus.isCactusSupported
 import coredevices.analytics.CoreAnalytics
-import coredevices.util.CommonBuildKonfig
 import coredevices.util.CoreConfigFlow
 import coredevices.util.models.CactusSTTMode
+import coredevices.util.models.SttModelCatalog
 import coredevices.util.writeWavHeader
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -200,9 +200,9 @@ class CactusTranscriptionService(
         val config = sttConfig.value
         if (config.mode == CactusSTTMode.RemoteOnly) return
         if (!isCactusSupported()) return
-        val sttModelName = CommonBuildKonfig.CACTUS_STT_MODEL
-        if (!modelProvider.isModelDownloaded(sttModelName)) {
-            logger.w { "STT model '$sttModelName' not downloaded, skipping init" }
+        val selectedSlug = config.modelName ?: SttModelCatalog.defaultSlug
+        if (!modelProvider.isModelDownloaded(selectedSlug)) {
+            logger.w { "STT model '$selectedSlug' not downloaded, skipping init" }
             return
         }
         val start = Clock.System.now()
@@ -213,7 +213,7 @@ class CactusTranscriptionService(
             }
         }
         if (modelHandle == 0L) {
-            val modelPath = modelProvider.getSTTModelPath()
+            val modelPath = modelProvider.getSTTModelPath(selectedSlug)
             modelHandle = cactusInit(modelPath, null, false)
             lastInitedModel = config.modelName
             val initDuration = Clock.System.now() - start
@@ -221,7 +221,8 @@ class CactusTranscriptionService(
         }
     }
 
-    private fun modelExists(): Boolean = modelProvider.isModelDownloaded(CommonBuildKonfig.CACTUS_STT_MODEL)
+    private fun modelExists(): Boolean =
+        modelProvider.isModelDownloaded(sttConfig.value.modelName ?: SttModelCatalog.defaultSlug)
 
     private fun performInit(): Job {
         return scope.launch(Dispatchers.IO) {

--- a/util/src/commonTest/kotlin/coredevices/util/models/SttModelCatalogTest.kt
+++ b/util/src/commonTest/kotlin/coredevices/util/models/SttModelCatalogTest.kt
@@ -1,0 +1,55 @@
+package coredevices.util.models
+
+import coredevices.util.CommonBuildKonfig
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class SttModelCatalogTest {
+
+    @Test
+    fun catalog_exposes_both_parakeet_models() {
+        val slugs = SttModelCatalog.models.map { it.slug }
+        assertTrue("parakeet-tdt-0.6b-v3" in slugs, "default v3 model missing")
+        assertTrue("parakeet-tdt-0.6b-v2" in slugs, "English v2 opt-in model missing")
+    }
+
+    @Test
+    fun default_slug_matches_build_constant() {
+        assertEquals(CommonBuildKonfig.CACTUS_STT_MODEL, SttModelCatalog.defaultSlug)
+        assertNotNull(SttModelCatalog.forSlug(SttModelCatalog.defaultSlug))
+    }
+
+    @Test
+    fun default_model_version_tracks_build_config() {
+        val default = SttModelCatalog.forSlug(SttModelCatalog.defaultSlug)
+        assertNotNull(default)
+        assertEquals(CommonBuildKonfig.CACTUS_STT_WEIGHTS_VERSION, default.version)
+    }
+
+    @Test
+    fun english_model_is_english_only_and_pinned_to_default_format_version() {
+        val en = SttModelCatalog.forSlug("parakeet-tdt-0.6b-v2")
+        assertNotNull(en)
+        assertTrue(en.englishOnly)
+        assertEquals(CommonBuildKonfig.CACTUS_STT_WEIGHTS_VERSION, en.version)
+        assertEquals("int8", en.quantization)
+    }
+
+    @Test
+    fun download_url_is_built_from_slug_version_and_quantization() {
+        assertEquals(
+            "https://huggingface.co/Cactus-Compute/parakeet-tdt-0.6b-v2/resolve/v1.10/weights/parakeet-tdt-0.6b-v2-int8.zip",
+            SttModelCatalog.downloadUrl("parakeet-tdt-0.6b-v2"),
+        )
+    }
+
+    @Test
+    fun unknown_slug_falls_back_to_default_weights_version() {
+        assertEquals(
+            CommonBuildKonfig.CACTUS_STT_WEIGHTS_VERSION,
+            SttModelCatalog.versionFor("whisper-small"),
+        )
+    }
+}


### PR DESCRIPTION
Adds a model picker for on-device speech recognition. SttModelCatalog becomes the source of truth for downloadable STT models and the engine loads the selected model (sttConfig.modelName) instead of always the CACTUS_STT_MODEL build constant. Two entries: the current multilingual default (parakeet-tdt-0.6b-v3, unchanged) and an English-only option (parakeet-tdt-0.6b-v2) with the same 0.6B int8 footprint and speed. Also: pick a model from the download-required prompt, real byte progress for Android downloads, catalog unit tests.

Why v2: it is measurably better on English. I benchmarked both through a simulation of the watch audio path matched to the firmware source (16 kHz mic, the x3 gain with clipping, Speex wideband 9800 bps, no pre-roll, wrist reverb and street noise), on easy watch commands and a hard corpus of names and alphanumerics. WER percent, sentences exactly right in parentheses:

| condition | v3 (default) | v2 (this PR) |
|---|---|---|
| wrist, quiet room | 0.8 (94%) | 0.0 (100%) |
| wrist, street noise | 2.0 (88%) | 1.6 (88%) |
| hard corpus, clean | 3.5 (71%) | 3.1 (75%) |
| hard corpus, street noise | 7.7 (50%) | 3.8 (67%) |

The corpus is TTS speech, so read the deltas rather than the absolute numbers. Consistent with the public figures: 6.05 versus 6.34 average English WER on the Hugging Face Open ASR leaderboard.

Weights: this expects Cactus-Compute/parakeet-tdt-0.6b-v2 in the same layout and format tag (v1.10) as the v3 repo, which does not exist yet. It is the same architecture Cactus already converts for v3, so it should be one converter run. Happy to help or contribute converted weights. Draft until then.

Catalog unit tests pass and the app compiles. The default path is unchanged.

Claude helped put this PR together.
