### PR TITLE
Add settings for Android's NotificationListener hints

### DIFF
--- a/pebble/src/commonMain/kotlin/coredevices/pebble/PebbleFeatures.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/PebbleFeatures.kt
@@ -8,6 +8,7 @@ class PebbleFeatures(
     fun supportsNotifiedOnlyFilter(): Boolean = platform == Platform.Android
     fun supportsNotificationCountSorting(): Boolean = platform == Platform.Android
     fun supportsNotificationLogging(): Boolean = platform == Platform.Android
+    fun supportsNotificationHints(): Boolean = platform == Platform.Android
     fun supportsPostTestNotification(): Boolean = platform == Platform.Android
     fun supportsDetectingOtherPebbleApps(): Boolean = platform == Platform.Android
     fun supportsBtClassic(): Boolean = platform == Platform.Android

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchSettingsScreen.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchSettingsScreen.kt
@@ -725,6 +725,40 @@ fun rememberSettingsItemsState(navBarNav: NavBarNav?, snackbarDisplay: SnackbarD
                     },
                     show = { pebbleFeatures.supportsNotificationFiltering() },
                 ),
+                basicSettingsToggleItem(
+                    title = "Mute phone notification effects",
+                    description = "Mutes the phone's own notification vibration/sound while the watch is connected",
+                    topLevelType = TopLevelType.Phone,
+                    section = Section.Notifications,
+                    checked = libPebbleConfig.notificationConfig.mutePhoneNotificationSoundsWhenConnected,
+                    onCheckChanged = {
+                        libPebble.updateConfig(
+                            libPebbleConfig.copy(
+                                notificationConfig = libPebbleConfig.notificationConfig.copy(
+                                    mutePhoneNotificationSoundsWhenConnected = it
+                                )
+                            )
+                        )
+                    },
+                    show = { pebbleFeatures.supportsNotificationHints() },
+                ),
+                basicSettingsToggleItem(
+                    title = "Mute phone call effects",
+                    description = "Mutes the phone's own call vibration/sound while the watch is connected",
+                    topLevelType = TopLevelType.Phone,
+                    section = Section.Notifications,
+                    checked = libPebbleConfig.notificationConfig.mutePhoneCallSoundsWhenConnected,
+                    onCheckChanged = {
+                        libPebble.updateConfig(
+                            libPebbleConfig.copy(
+                                notificationConfig = libPebbleConfig.notificationConfig.copy(
+                                    mutePhoneCallSoundsWhenConnected = it
+                                )
+                            )
+                        )
+                    },
+                    show = { pebbleFeatures.supportsNotificationHints() },
+                ),
                 SettingsItem(
                     title = "Vibration Pattern",
                     topLevelType = TopLevelType.Phone,


### PR DESCRIPTION
This allows for the Pebble's NotificationListener to "mute" notifications on the device while it is active; allowing the watch to take over the duty of vibrating for incoming notifications.

(libpebble3 already had this wired up, just needed to expose the settings :))