### PR TITLE
Fix iOS simulator linking and close iOS setup doc gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,21 @@ Several features (e.g. bug reporting, google login, memfault, online transcripti
    sdk.dir=/Users/<you>/Library/Android/sdk
    ```
 
+4. **Install the iOS platform for Xcode**
+
+   Recent Xcode versions ship without the iOS platform (SDK device
+   support and simulator runtime). Without it, any iOS build fails with
+   "iOS X.Y is not installed". Download it with:
+
+   ```bash
+   xcodebuild -downloadPlatform iOS
+   ```
+
+   (This is the same ~8 GB download as Xcode → Settings → Components.)
+
 #### Configuration
 
-4. **Configure Entitlements**
+5. **Configure Entitlements**
 
    Set `iosApp/iosApp/iosApp.entitlements` to:
 
@@ -103,7 +115,7 @@ Several features (e.g. bug reporting, google login, memfault, online transcripti
    </plist>
    ```
 
-5. **Install CocoaPods dependencies**
+6. **Install CocoaPods dependencies**
 
    ```bash
    ./gradlew podInstall
@@ -111,21 +123,21 @@ Several features (e.g. bug reporting, google login, memfault, online transcripti
 
    This will create `Podfile.lock` and set up all required dependencies.
 
-6. **Configure Bundle ID and Signing**
+7. **Configure Bundle ID and Signing**
 
    - Open `iosApp/iosApp.xcworkspace` in Xcode (⚠️ **Important**: use `.xcworkspace`, not `.xcodeproj`)
    - Go to the target `iosApp` → **Signing & Capabilities**
    - Set your **Team** (your Apple Developer account)
    - Set **Bundle Identifier** to your own (e.g., `com.yourname.coredevices.coreapp`)
 
-7. **Configure Firebase**
+8. **Configure Firebase**
 
    - Create a free Firebase account at https://console.firebase.google.com
    - Create a new iOS app with the same Bundle ID you set above
    - Download `GoogleService-Info.plist` and place it in `iosApp/iosApp/`
    - The file should be named exactly `GoogleService-Info.plist`
 
-8. **Create a git tag for app version**
+9. **Create a git tag for app version**
 
    Create a git tag that will be used as the version of the app:
 
@@ -135,7 +147,7 @@ Several features (e.g. bug reporting, google login, memfault, online transcripti
 
 #### Build and Run
 
-9. **Build and run in Xcode**
+10. **Build and run in Xcode**
 
    - Open `iosApp/iosApp.xcworkspace` in Xcode
    - Select your target device or simulator and run.

--- a/README.md
+++ b/README.md
@@ -72,9 +72,19 @@ Several features (e.g. bug reporting, google login, memfault, online transcripti
    sudo ln -s /opt/homebrew/bin/pod /usr/local/bin/pod
    ```
 
-3. **Setup GitHub token for speex module**
+3. **Install Android Studio**
 
-    Create a `local.properties` file in the project root with your GitHub credentials.
+   The Gradle build needs an Android SDK even when only building for iOS
+   (several modules apply the Android Gradle plugin). Install
+   [Android Studio](https://developer.android.com/studio) and let its
+   setup wizard install the SDK at the default location
+   (`~/Library/Android/sdk`).
+
+   Then create a `local.properties` file in the project root pointing at it:
+
+   ```properties
+   sdk.dir=/Users/<you>/Library/Android/sdk
+   ```
 
 #### Configuration
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,14 @@ Several features (e.g. bug reporting, google login, memfault, online transcripti
    - Download `GoogleService-Info.plist` and place it in `iosApp/iosApp/`
    - The file should be named exactly `GoogleService-Info.plist`
 
+   If you don't need any Firebase-dependent features, you can skip the
+   Firebase account and use the provided dummy config instead (same as
+   `google-services-dummy.json` on Android):
+
+   ```bash
+   cp iosApp/iosApp/GoogleService-Info-dummy.plist iosApp/iosApp/GoogleService-Info.plist
+   ```
+
 9. **Create a git tag for app version**
 
    Create a git tag that will be used as the version of the app:

--- a/README.md
+++ b/README.md
@@ -165,6 +165,14 @@ Several features (e.g. bug reporting, google login, memfault, online transcripti
    > - Ran `pod install` successfully
    > - Cleaned the build folder (`Product → Clean Build Folder`)
 
+   > **Known issue**: simulator builds currently fail to link with
+   > `ld: building for 'iOS-simulator', but linking in object file (...libspeex.a...) built for 'iOS'`.
+   > The published `io.github.coredevices.speex` simulator artifact ships a
+   > device-built `libspeex.a` inside its iosSimulatorArm64 klib (every
+   > version on Maven Central is affected) and needs to be republished.
+   > Until then, run on a physical device. Note the simulator has no
+   > Bluetooth in any case, so connecting a watch requires a device.
+
 
 
 

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -119,7 +119,7 @@ kotlin {
                 linkerOpts(
                     "-framework", "LibPebbleSwift", "-F"+dir.absolutePath,
                     "-weak_framework", "CoreML",
-                    "-L$xcodeDir/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphoneos"
+                    "-L$xcodeDir/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$osName"
                 )
             }
         }

--- a/iosApp/iosApp/GoogleService-Info-dummy.plist
+++ b/iosApp/iosApp/GoogleService-Info-dummy.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>API_KEY</key>
+	<string>AIzaSyA-replaceme-replaceme-replaceme00</string>
+	<key>GCM_SENDER_ID</key>
+	<string>000000000000</string>
+	<key>PLIST_VERSION</key>
+	<string>1</string>
+	<key>BUNDLE_ID</key>
+	<string>coredevices.coreapp</string>
+	<key>PROJECT_ID</key>
+	<string>replaceme</string>
+	<key>STORAGE_BUCKET</key>
+	<string>replaceme.appspot.com</string>
+	<key>IS_ADS_ENABLED</key>
+	<false/>
+	<key>IS_ANALYTICS_ENABLED</key>
+	<false/>
+	<key>IS_APPINVITE_ENABLED</key>
+	<false/>
+	<key>IS_GCM_ENABLED</key>
+	<false/>
+	<key>IS_SIGNIN_ENABLED</key>
+	<false/>
+	<key>GOOGLE_APP_ID</key>
+	<string>1:000000000000:ios:0000000000000000</string>
+</dict>
+</plist>


### PR DESCRIPTION
Went through the iOS setup on a fresh machine (macOS, Xcode 26.6) following the README, and hit a few issues along the way. This PR fixes what can be fixed in this repo and updates the docs for the rest.

## Code fix

- **`composeApp/build.gradle.kts` hardcoded the device Swift toolchain library path** (`usr/lib/swift/iphoneos`) in the framework linker options for all Apple targets, while the per-target `osName` computed right above is only used for the LibPebbleSwift directory. On simulator links (deployment target < iOS 15) the Swift driver autolinks `libswiftCompatibility56.a`, and the hardcoded path made `ld` pick the device build of it, hard-failing the link. Went unnoticed because CI only builds `iosArm64`.

## Doc fixes

- **The "GitHub token for speex" prerequisite is stale**: speex resolves from Maven Central now, and no build script reads GitHub credentials from `local.properties`. What a fresh setup actually needs there is `sdk.dir` — the Gradle build requires an Android SDK even for iOS-only builds ("SDK location not found" otherwise). Replaced the step with Android Studio + `local.properties` instructions.
- **Recent Xcode ships without the iOS platform** — on a fresh install, any iOS build fails with "iOS X.Y is not installed". Documented `xcodebuild -downloadPlatform iOS`.
- **Firebase account shouldn't be required just to build**: added `GoogleService-Info-dummy.plist` (iOS counterpart of `google-services-dummy.json`) and documented copying it into place. The app builds and runs fine with it.

## Known issue (needs a fix outside this repo)

Even with the linker path fix, **simulator builds still fail**: every published version of `io.github.coredevices.speex` on Maven Central ships a device-built `libspeex.a` inside the iosSimulatorArm64 cinterop klib — all 31 objects are tagged `LC_BUILD_VERSION` platform 2 (iOS) instead of 7 (iOS-Simulator). The library needs to be rebuilt/republished with a proper simulator slice; I added a known-issue note to the README pointing at the failure signature. (I verified the rest of the chain works by patching the platform tags in the cached klib locally — with that plus the linker path fix, the app builds, installs and runs on the iOS 26.5 simulator.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)