### PR TITLE
DataLogging: share third-party sessions with companion apps

### DIFF
--- a/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/pebblekit/classic/io/rebble/libpebblecommon/pebblekit/classic/PebbleKitClassic.kt
+++ b/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/pebblekit/classic/io/rebble/libpebblecommon/pebblekit/classic/PebbleKitClassic.kt
@@ -6,6 +6,7 @@ import android.content.IntentFilter
 import co.touchlab.kermit.Logger
 import io.rebble.libpebblecommon.connection.CompanionApp
 import io.rebble.libpebblecommon.connection.ConnectedPebble
+import io.rebble.libpebblecommon.datalogging.Datalogging
 import io.rebble.libpebblecommon.di.ConnectionCoroutineScope
 import io.rebble.libpebblecommon.di.LibPebbleKoinComponent
 import io.rebble.libpebblecommon.js.CompanionAppDevice
@@ -21,6 +22,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -45,6 +47,7 @@ class PebbleKitClassic(
     private var runningScope: CoroutineScope? = null
 
     private val context: Context = getKoin().get()
+    private val datalogging: Datalogging = getKoin().get()
 
     private suspend fun replyNACK(id: UByte) {
         withTimeoutOrNull(1000) {
@@ -76,6 +79,40 @@ class PebbleKitClassic(
         }.catch {
             logger.e(it) { "Error receiving app message: ${it.message}" }
         }.launchIn(scope)
+    }
+
+    // Deliver a watchapp's DataLogging (offline flash spool) to this companion on reconnect,
+    // mirroring the app.RECEIVE path.
+    private fun launchDataloggingHandler(scope: CoroutineScope) {
+        datalogging.thirdPartyData
+            .filter { it.uuid == uuid }
+            .onEach { record ->
+                val intent = Intent(INTENT_DATALOG_RECEIVE).apply {
+                    putExtra(APP_UUID, record.uuid.toJavaUuid())
+                    putExtra(DATALOG_TIMESTAMP, record.timestamp.toLong())   // session start epoch = stable session id
+                    putExtra(DATALOG_TAG, record.tag.toInt())
+                    putExtra(DATALOG_ITEM_SIZE, record.itemSize.toInt())
+                    putExtra(DATALOG_ITEMS_LEFT, record.itemsLeft.toLong())
+                    putExtra(DATALOG_DATA, record.data)
+                }
+                context.sendOrderedBroadcast(intent, null)
+            }.catch {
+                logger.e(it) { "Error delivering datalog for $uuid: ${it.message}" }
+            }.launchIn(scope)
+
+        // Session close → FINISH_SESSION.
+        datalogging.thirdPartyFinished
+            .filter { it.uuid == uuid }
+            .onEach { fin ->
+                val intent = Intent(INTENT_DATALOG_FINISH).apply {
+                    putExtra(APP_UUID, fin.uuid.toJavaUuid())
+                    putExtra(DATALOG_TIMESTAMP, fin.timestamp.toLong())
+                    putExtra(DATALOG_TAG, fin.tag.toInt())
+                }
+                context.sendOrderedBroadcast(intent, null)
+            }.catch {
+                logger.e(it) { "Error delivering datalog finish for $uuid: ${it.message}" }
+            }.launchIn(scope)
     }
 
     // TODO app start and stop intents
@@ -135,6 +172,7 @@ class PebbleKitClassic(
         runningScope = scope
         launchIncomingAppMessageHandler(incomingAppMessages, scope)
         launchOutgoingAppMessageHandlers(device, scope)
+        launchDataloggingHandler(scope)
     }
 
     override suspend fun stop() {
@@ -231,3 +269,12 @@ private const val APP_UUID = "uuid"
  * The bundle-key used to store a message's JSON payload send-to or received-from the watch.
  */
 private const val MSG_DATA = "msg_data"
+
+/** Broadcasts delivering a watchapp's DataLogging (offline flash spool) to companion apps, mirroring the app.* intents. */
+private const val INTENT_DATALOG_RECEIVE = "com.getpebble.action.datalogging.RECEIVE_DATA"
+private const val INTENT_DATALOG_FINISH = "com.getpebble.action.datalogging.FINISH_SESSION"
+private const val DATALOG_TIMESTAMP = "data_log_timestamp"   // session start epoch = session id
+private const val DATALOG_TAG = "data_log_tag"
+private const val DATALOG_ITEM_SIZE = "data_item_size"
+private const val DATALOG_ITEMS_LEFT = "data_items_left"
+private const val DATALOG_DATA = "data"

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/datalogging/Datalogging.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/datalogging/Datalogging.kt
@@ -9,6 +9,9 @@ import io.rebble.libpebblecommon.structmapper.SUInt
 import io.rebble.libpebblecommon.structmapper.StructMappable
 import io.rebble.libpebblecommon.util.DataBuffer
 import io.rebble.libpebblecommon.util.Endian
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlin.uuid.Uuid
 
 class Datalogging(
@@ -16,6 +19,15 @@ class Datalogging(
     private val healthDataProcessor: HealthDataProcessor,
 ) {
     private val logger = Logger.withTag("Datalogging")
+
+    // Non-health, non-system datalogging, exposed for PebbleKit to deliver to companion apps
+    // (was dropped). Parity with legacy PebbleDataLogReceiver.
+    private val _thirdPartyData = MutableSharedFlow<ThirdPartyDatalogRecord>(extraBufferCapacity = 128)
+    val thirdPartyData: SharedFlow<ThirdPartyDatalogRecord> = _thirdPartyData.asSharedFlow()
+
+    // Third-party session close, so companions can finalize a recording (legacy FINISH_SESSION).
+    private val _thirdPartyFinished = MutableSharedFlow<ThirdPartyDatalogFinish>(extraBufferCapacity = 16)
+    val thirdPartyFinished: SharedFlow<ThirdPartyDatalogFinish> = _thirdPartyFinished.asSharedFlow()
 
     fun logData(
         sessionId: UByte,
@@ -25,6 +37,7 @@ class Datalogging(
         watchInfo: WatchInfo,
         itemSize: UShort,
         itemsLeft: UInt,
+        timestamp: UInt = 0u,
     ) {
         // Handle health tags
         if (tag in HealthDataProcessor.HEALTH_TAGS) {
@@ -63,6 +76,12 @@ class Datalogging(
                     }
                 }
             }
+            return
+        }
+
+        // Third-party app data — deliver to companion apps instead of dropping it.
+        if (!_thirdPartyData.tryEmit(ThirdPartyDatalogRecord(uuid, tag, timestamp, itemSize, itemsLeft, data))) {
+            logger.w { "third-party datalog buffer full; dropped ${data.size} B for $uuid" }
         }
     }
 
@@ -72,10 +91,14 @@ class Datalogging(
         }
     }
 
-    fun closeSession(sessionId: UByte, tag: UInt) {
+    fun closeSession(sessionId: UByte, tag: UInt, uuid: Uuid = Uuid.NIL, timestamp: UInt = 0u) {
         if (tag in HealthDataProcessor.HEALTH_TAGS) {
             healthDataProcessor.handleSessionClose(sessionId)
+            return
         }
+        if (uuid == SYSTEM_APP_UUID) return
+        // Third-party session finished — let companion apps finalize the recording.
+        _thirdPartyFinished.tryEmit(ThirdPartyDatalogFinish(uuid, tag, timestamp))
     }
 
     companion object {
@@ -83,6 +106,23 @@ class Datalogging(
         private val ANALYTICS_HEARTBEAT_TAG: UInt = 87u
     }
 }
+
+/** A batch of datalogging items from a third-party watchapp, for delivery to companion apps. */
+data class ThirdPartyDatalogRecord(
+    val uuid: Uuid,
+    val tag: UInt,
+    val timestamp: UInt,   // session start epoch — stable session id
+    val itemSize: UShort,
+    val itemsLeft: UInt,
+    val data: ByteArray,
+)
+
+/** A third-party datalogging session closing (watch called data_logging_finish). */
+data class ThirdPartyDatalogFinish(
+    val uuid: Uuid,
+    val tag: UInt,
+    val timestamp: UInt,
+)
 
 class MemfaultChunk : StructMappable() {
     val chunkSize: SUInt = SUInt(m, 0u, Endian.Little)

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/services/DataLoggingService.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/services/DataLoggingService.kt
@@ -50,8 +50,9 @@ class DataLoggingService(
                     val tag = it.tag.get()
                     val applicationUuid = it.applicationUUID.get()
                     val itemSize = it.dataItemSize.get()
+                    val timestamp = it.timestamp.get()
                     logger.d { "Session opened: $id tag: $tag (accepted: $acceptSessions)" }
-                    sessions[id] = DataLoggingSession(id, tag, applicationUuid, itemSize)
+                    sessions[id] = DataLoggingSession(id, tag, applicationUuid, itemSize, timestamp)
                     datalogging.openSession(id, tag, applicationUuid, itemSize)
                     sendAckNack(id)
                 }
@@ -77,6 +78,7 @@ class DataLoggingService(
                         watchInfo = info,
                         itemSize = session.itemSize,
                         itemsLeft = it.itemsLeftAfterThis.get(),
+                        timestamp = session.timestamp,
                     )
                 }
 
@@ -85,7 +87,7 @@ class DataLoggingService(
                     val session = sessions[id]
                     logger.d { "Session closed: $id" }
                     if (session != null) {
-                        datalogging.closeSession(id, session.tag)
+                        datalogging.closeSession(id, session.tag, session.uuid, session.timestamp)
                     }
                     sessions.remove(id)
                     sendAckNack(id)
@@ -100,4 +102,5 @@ data class DataLoggingSession(
     val tag: UInt,
     val uuid: Uuid,
     val itemSize: UShort,
+    val timestamp: UInt = 0u,   // session start epoch, from OpenSession
 )


### PR DESCRIPTION
# TLDR

Hi!
I've been developing a custom swimming tracker app and found that the DataLogging API doesn't allow third-party apps to read it. Could we restore the legacy API?
I've also tried using AppMessage for delivery, but unfortunately it's unreliable and requires the phone to be near the pool. Also, if the signal is lost over a certain distance, it can't recover the ACK loop, which renders it stuck forever.

# Share third-party DataLogging with companion apps

A third-party watch app can write to DataLogging (the flash spool that buffers sensor data offline and syncs when the app reconnects) but can never get its data back. The `Datalogging.logData()` function only routes health tags and telemetry, and silently drops everything else. So, you can't log offline if your phone is out of range. This means that apps have to stream live over AppMessage (your phone has to stay within Bluetooth range). This makes apps unusable for things like a swim tracker.

This brings back the old 'PebbleDataLogReceiver' path. When the app is reconnected, it starts logging data again. The health/system paths haven't been changed!

## Change

`Datalogging` + `DataLoggingService`

- Expose non-health, non-system sessions instead of dropping them: `thirdPartyData: SharedFlow<ThirdPartyDatalogRecord>`, plus `thirdPartyFinished` on session close.
- Thread the `OpenSession` timestamp (watch session start epoch) through `DataLoggingSession` so companions get a stable session id.

`PebbleKitClassic`

- Broadcast to registered companion apps, mirroring the existing `app.*` delivery:
  `com.getpebble.action.datalogging.RECEIVE_DATA` (extras: `uuid`, `data_log_timestamp`, etc) and `FINISH_SESSION`

## Testing

On Pebble Time 2 (fw v4.19.2): A watch app logged 166-byte records under a non-system UUID when the phone was out of Bluetooth range for the whole session. When the Bluetooth connection was re-established, the companion received every record (accelerometer, heart rate and compass, with no loss of data), keyed by the start of the session and finalized by 'FINISH_SESSION'. Health, Memfault or Analytics paths haven't changed.