### PR TITLE
Add AMOLED-style Black theme option

### DIFF
--- a/composeApp/src/androidMain/kotlin/coredevices/coreapp/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/coredevices/coreapp/MainActivity.kt
@@ -102,6 +102,7 @@ class MainActivity : ComponentActivity() {
         val themeRes = when (theme) {
             CoreAppTheme.Light -> light
             CoreAppTheme.Dark -> dark
+            CoreAppTheme.Black -> R.style.Theme_CoreApp_Black
             CoreAppTheme.System -> if (isNightMode(this)) {
                 dark
             } else {

--- a/composeApp/src/androidMain/res/values/themes.xml
+++ b/composeApp/src/androidMain/res/values/themes.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<resources>
+    <!-- Window background is painted before Compose composes; the platform dark theme's grey
+         would flash before the black scheme takes over. -->
+    <style name="Theme.CoreApp.Black" parent="@android:style/Theme.Material.NoActionBar">
+        <item name="android:windowBackground">@android:color/black</item>
+    </style>
+</resources>

--- a/experimental/src/commonMain/kotlin/coredevices/ring/ui/theme/IndexTheme.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/ui/theme/IndexTheme.kt
@@ -4,7 +4,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
-import theme.CoreAppColorScheme
 import theme.currentColorScheme
 
 /**
@@ -126,7 +125,7 @@ fun IndexThemeHost(
     forceDark: Boolean? = null,
     content: @Composable () -> Unit,
 ) {
-    val dark = forceDark ?: (currentColorScheme() == CoreAppColorScheme.Grey)
+    val dark = forceDark ?: currentColorScheme().isDark
     val colors = if (dark) IndexColors.Dark else IndexColors.Light
     androidx.compose.runtime.CompositionLocalProvider(
         LocalIndexColors provides colors,

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchSettingsScreen.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchSettingsScreen.kt
@@ -169,7 +169,6 @@ import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
-import theme.CoreAppColorScheme
 import theme.CoreAppTheme
 import theme.ThemeProvider
 import theme.currentColorScheme
@@ -1465,7 +1464,7 @@ fun rememberSettingsItemsState(navBarNav: NavBarNav?, snackbarDisplay: SnackbarD
                     section = Section.Speech,
                     keywords = "",
                     item = {
-                        val logo = if (currentColorScheme() == CoreAppColorScheme.Grey) {
+                        val logo = if (currentColorScheme().isDark) {
                             Res.drawable.wispr_flow_logo_white
                         } else {
                             Res.drawable.wispr_flow_logo_black

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchesScreen.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchesScreen.kt
@@ -86,7 +86,6 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.MenuDefaults
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
@@ -204,9 +203,7 @@ import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.koinInject
 import org.koin.dsl.module
-import theme.CoreAppColorScheme
 import theme.coreOrange
-import theme.currentColorScheme
 import kotlin.time.Clock
 import kotlin.uuid.Uuid
 
@@ -1235,7 +1232,6 @@ fun WatchMenu(watch: PebbleDevice, navBarNav: NavBarNav) {
     val showConfirmResetIntoPrfDialog = remember { mutableStateOf(false) }
     val showConfirmFactoryResetDialog = remember { mutableStateOf(false) }
     val scope = rememberCoroutineScope()
-    val currentColorScheme = currentColorScheme()
 
     Box {
         IconButton(onClick = { showMenu = !showMenu }) {
@@ -1244,20 +1240,7 @@ fun WatchMenu(watch: PebbleDevice, navBarNav: NavBarNav) {
         DropdownMenu(
             expanded = showMenu,
             onDismissRequest = { showMenu = false },
-            modifier = Modifier.widthIn(min = 250.dp).then(
-                if (currentColorScheme == CoreAppColorScheme.Grey) {
-                    Modifier.border(
-                        width = 1.5.dp,
-                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f),
-                        shape = RoundedCornerShape(4.dp)
-                    )
-                } else Modifier
-            ),
-            containerColor = if (currentColorScheme == CoreAppColorScheme.Grey) {
-                MaterialTheme.colorScheme.surfaceContainerHigh
-            } else {
-                MenuDefaults.containerColor
-            },
+            modifier = Modifier.widthIn(min = 250.dp),
         ) {
             val firmwareVersion = when {
                 watch is KnownPebbleDevice -> watch.runningFwVersion

--- a/util/src/androidMain/kotlin/theme/Theme.android.kt
+++ b/util/src/androidMain/kotlin/theme/Theme.android.kt
@@ -13,27 +13,12 @@ actual fun setStatusBarTheme(colorScheme: CoreAppColorScheme) {
     val activity = LocalActivity.current as? ComponentActivity
     LaunchedEffect(colorScheme) {
         if (activity != null) {
-            when (colorScheme) {
-                CoreAppColorScheme.Grey -> activity.enableEdgeToEdge(
-                    statusBarStyle = SystemBarStyle.dark(
-                        Color.TRANSPARENT,
-                    ),
-                    navigationBarStyle = SystemBarStyle.dark(
-                        Color.TRANSPARENT,
-                    ),
-                )
-
-                CoreAppColorScheme.Light -> activity.enableEdgeToEdge(
-                    statusBarStyle = SystemBarStyle.light(
-                        Color.TRANSPARENT,
-                        Color.TRANSPARENT,
-                    ),
-                    navigationBarStyle = SystemBarStyle.light(
-                        Color.TRANSPARENT,
-                        Color.TRANSPARENT,
-                    ),
-                )
+            val style = if (colorScheme.isDark) {
+                SystemBarStyle.dark(Color.TRANSPARENT)
+            } else {
+                SystemBarStyle.light(Color.TRANSPARENT, Color.TRANSPARENT)
             }
+            activity.enableEdgeToEdge(statusBarStyle = style, navigationBarStyle = style)
         }
     }
 }

--- a/util/src/commonMain/composeResources/values/strings.xml
+++ b/util/src/commonMain/composeResources/values/strings.xml
@@ -4,5 +4,6 @@
     <string name="settings">Settings</string>
     <string name="light">Light</string>
     <string name="dark">Dark</string>
+    <string name="black">Black</string>
     <string name="system">System</string>
 </resources>

--- a/util/src/commonMain/kotlin/theme/Theme.kt
+++ b/util/src/commonMain/kotlin/theme/Theme.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
 import com.russhwolf.settings.Settings
 import coreapp.util.generated.resources.Res
+import coreapp.util.generated.resources.black
 import coreapp.util.generated.resources.dark
 import coreapp.util.generated.resources.light
 import coreapp.util.generated.resources.system
@@ -54,7 +55,27 @@ val greyScheme = darkColorScheme(
     outline = outlineDark,
     outlineVariant = outlineVariantDark,
     scrim = coreGrey,
-    surfaceContainer = coreGrey,
+    surfaceDim = Color(0xFF262626),
+    surfaceBright = Color(0xFF4D4D4D),
+    surfaceContainerLowest = Color(0xFF1A1A1A),
+    surfaceContainerLow = Color(0xFF262626),
+    surfaceContainer = Color(0xFF3D3D3D),
+    surfaceContainerHigh = Color(0xFF474747),
+    surfaceContainerHighest = Color(0xFF525252),
+)
+
+// Containers must ascend lowest -> highest, and surfaceContainer must clear `surface`: it is what
+// menus and popups paint themselves, so matching the page behind them leaves them with no edge.
+val blackScheme = greyScheme.copy(
+    background = Color.Black,
+    surface = Color.Black,
+    scrim = Color.Black,
+    surfaceDim = Color.Black,
+    surfaceBright = coreDarkGrey,
+    surfaceContainerLowest = Color.Black,
+    surfaceContainerLow = Color(0xFF0D0D0D),
+    surfaceContainer = Color(0xFF141414),
+    surfaceContainerHigh = Color(0xFF1F1F1F),
     surfaceContainerHighest = coreDarkGrey,
 )
 
@@ -149,6 +170,7 @@ data class ColorFamily(
 enum class CoreAppTheme(val resource: StringResource, val key: String) {
     Light(Res.string.light, "light"),
     Dark(Res.string.dark, "dark"),
+    Black(Res.string.black, "black"),
     System(Res.string.system, "system"),
     ;
 
@@ -158,9 +180,10 @@ enum class CoreAppTheme(val resource: StringResource, val key: String) {
     }
 }
 
-enum class CoreAppColorScheme {
-    Light,
-    Grey,
+enum class CoreAppColorScheme(val isDark: Boolean) {
+    Light(false),
+    Grey(true),
+    Black(true),
 }
 
 @Composable
@@ -172,6 +195,7 @@ fun currentColorScheme(): CoreAppColorScheme {
         when (theme) {
             CoreAppTheme.Light -> CoreAppColorScheme.Light
             CoreAppTheme.Dark -> CoreAppColorScheme.Grey
+            CoreAppTheme.Black -> CoreAppColorScheme.Black
             CoreAppTheme.System -> if (systemInDarkTheme) CoreAppColorScheme.Grey else CoreAppColorScheme.Light
         }
     }
@@ -183,11 +207,12 @@ fun AppTheme(
     content: @Composable() () -> Unit
 ) {
     val colorScheme = currentColorScheme()
-    val extendedColors = if (colorScheme == CoreAppColorScheme.Grey) darkExtendedColors else lightExtendedColors
+    val extendedColors = if (colorScheme.isDark) darkExtendedColors else lightExtendedColors
     setStatusBarTheme(colorScheme)
     val materialColorScheme = when (colorScheme) {
         CoreAppColorScheme.Light -> lightScheme
         CoreAppColorScheme.Grey -> greyScheme
+        CoreAppColorScheme.Black -> blackScheme
     }
     CompositionLocalProvider(LocalExtendedColors provides extendedColors) {
         MaterialTheme(

--- a/util/src/commonTest/kotlin/theme/ThemeTest.kt
+++ b/util/src/commonTest/kotlin/theme/ThemeTest.kt
@@ -1,0 +1,69 @@
+package theme
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
+import theme.CoreAppTheme.Companion.asCoreAppTheme
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ThemeTest {
+    @Test
+    fun `dark schemes report isDark`() {
+        assertTrue(CoreAppColorScheme.Grey.isDark)
+        assertTrue(CoreAppColorScheme.Black.isDark)
+        assertFalse(CoreAppColorScheme.Light.isDark)
+    }
+
+    @Test
+    fun `theme keys round trip`() {
+        CoreAppTheme.entries.forEach {
+            assertEquals(it, it.key.asCoreAppTheme())
+        }
+    }
+
+    @Test
+    fun `unknown theme key falls back to system`() {
+        assertEquals(CoreAppTheme.System, null.asCoreAppTheme())
+        assertEquals(CoreAppTheme.System, "amoled".asCoreAppTheme())
+    }
+
+    @Test
+    fun `black scheme is true black and distinct from grey`() {
+        assertEquals(Color.Black, blackScheme.background)
+        assertEquals(Color.Black, blackScheme.surface)
+        assertTrue(blackScheme.background != greyScheme.background)
+        assertTrue(blackScheme.surface != greyScheme.surface)
+    }
+
+    @Test
+    fun `dark scheme container roles ascend`() {
+        listOf("black" to blackScheme, "grey" to greyScheme).forEach { (schemeName, scheme) ->
+            val ladder = listOf(
+                "surfaceContainerLowest" to scheme.surfaceContainerLowest,
+                "surfaceContainerLow" to scheme.surfaceContainerLow,
+                "surfaceContainer" to scheme.surfaceContainer,
+                "surfaceContainerHigh" to scheme.surfaceContainerHigh,
+                "surfaceContainerHighest" to scheme.surfaceContainerHighest,
+            )
+            ladder.zipWithNext { (lowerName, lower), (higherName, higher) ->
+                assertTrue(
+                    lower.luminance() <= higher.luminance(),
+                    "$schemeName: $lowerName (${lower.luminance()}) is lighter than " +
+                        "$higherName (${higher.luminance()})",
+                )
+            }
+        }
+    }
+
+    // Menus paint themselves surfaceContainer. On the dark schemes that has to clear the page, which
+    // shadow elevation cannot do for them the way it does on light.
+    @Test
+    fun `dark scheme menu containers are distinct from the page`() {
+        listOf(blackScheme, greyScheme).forEach { scheme ->
+            assertTrue(scheme.surfaceContainer != scheme.surface)
+            assertTrue(scheme.surfaceContainer != scheme.background)
+        }
+    }
+}

--- a/util/src/iosMain/kotlin/coredevices/ui/PebbleWebview.ios.kt
+++ b/util/src/iosMain/kotlin/coredevices/ui/PebbleWebview.ios.kt
@@ -24,7 +24,6 @@ import platform.WebKit.WKWebView
 import platform.WebKit.WKWebViewConfiguration
 import platform.WebKit.javaScriptEnabled
 import platform.darwin.NSObject
-import theme.CoreAppColorScheme
 import theme.currentColorScheme
 
 private val logger = Logger.withTag("PebbleWebview")
@@ -146,9 +145,10 @@ actual fun PebbleWebview(
     // matches the app's App Theme setting, not the OS setting.
     val colorScheme = currentColorScheme()
     LaunchedEffect(colorScheme) {
-        webView.overrideUserInterfaceStyle = when (colorScheme) {
-            CoreAppColorScheme.Grey -> UIUserInterfaceStyle.UIUserInterfaceStyleDark
-            CoreAppColorScheme.Light -> UIUserInterfaceStyle.UIUserInterfaceStyleLight
+        webView.overrideUserInterfaceStyle = if (colorScheme.isDark) {
+            UIUserInterfaceStyle.UIUserInterfaceStyleDark
+        } else {
+            UIUserInterfaceStyle.UIUserInterfaceStyleLight
         }
     }
 


### PR DESCRIPTION
# Add AMOLED black theme

Adds a third app theme — **Black** — alongside Light and Dark, for OLED screens where a true-black background costs no backlight power.
Also fixes some minor readability issues with the original Dark theme, which would have carried over to the new Black theme (see below).

## What you get

A new "Black" option in the app theme picker. It's the existing Dark scheme with `background`, `surface`, and the lowest container role painted pure black.

## The interesting part: the surface ladder

Material 3 gives every scheme a ladder of container colours (`surfaceContainerLowest` → `surfaceContainerHighest`) that components use to lift themselves off the page. A `DropdownMenu`, for example, paints itself `surfaceContainer`.

Both dark schemes had a broken ladder when I first implemented this:

- `surfaceContainer` was set to the **same colour as `surface`**, so popups had almost no visible edge against the page behind them.
- In the Dark scheme, `surfaceContainerHighest` was **darker** than the page above it, so elevation read inverted.
- Everything left unnamed fell through to the M3 dark defaults, which are near-black — wrong against a `#333333` page.

Both ladders now ascend cleanly. Because the scheme carries the difference, components separate themselves correctly with **no per-component styling** — which is why this PR deletes the `== Grey` menu special case in `WatchesScreen` rather than generalising it.

Light theme is deliberately untouched: it separates menus via shadow elevation, which works on white. Dark themes suppress shadows, which is exactly why M3 uses tonal elevation there instead.

## Theme-carried `isDark`

`CoreAppColorScheme` now carries an `isDark` flag instead of callers testing `== Grey`. Two places were picking a dark asset by comparing against the Dark theme specifically, so Black got the wrong one: the Wispr Flow logo (rendered black-on-black) and the webview's `prefers-color-scheme`. Both now follow the flag.

## Files

10 files, +121 / −51. The substance is in `util/src/commonMain/kotlin/theme/Theme.kt`; most of the rest is one- to three-line touches.

## Testing

- `:composeApp:assembleDebug` — passing
- `:util:testDebugUnitTest` — passing, including new coverage asserting both dark ladders ascend and that menu containers clear the page colour

**Not yet verified on iOS.** The only iOS-side change is one deleted import in `PebbleWebview.ios.kt` (`isDark` became a member property, so it resolves without one). It could not be compiled locally: `:util:compileKotlinIosSimulatorArm64` fails in `libpebble3` on an unresolved `LibPebbleSwift` reference, which needs `podInstall` and reproduces on a clean checkout — pre-existing, unrelated to this change. Worth a build on macOS before merge.

## Worth a look when reviewing

The Dark theme ladder fix **restyles the shipped Dark theme**, not just the new Black one. It was unavoidable — the ladder is what makes menus work without per-component styling, so leaving Dark broken would have meant keeping the special case. Surfaces in Dark will look slightly different: containers now sit lighter than the page rather than darker.

## Screenshots

### Old vs. New Dark Theme, and New Black Theme
<img width="32%" src="https://github.com/user-attachments/assets/43774ef7-a38b-4003-aeb4-91a4a729e348" />
<img width="32%" src="https://github.com/user-attachments/assets/02e0101b-5307-4c9e-a780-a0c550d6b3ea" />
<img width="32%" src="https://github.com/user-attachments/assets/39ccebeb-0fb8-4922-84c9-4ca7bc927dc5" />

## AI Disclosure

I used Claude (Sonnet 5 and Opus 4.8) to work on this feature. I am very new to Kotlin (but not coding in general), so using AI to help build out a maintainable new theme like this seemed appropriate. I am fully open to hearing out any changes you'd like to see before this is merged.