### PR TITLE
Add Index trigger gesture to webhook headers

### DIFF
--- a/composeApp/src/androidInstrumentedTest/kotlin/coredevices/coreapp/evals/RingRecordingE2ETest.kt
+++ b/composeApp/src/androidInstrumentedTest/kotlin/coredevices/coreapp/evals/RingRecordingE2ETest.kt
@@ -649,7 +649,14 @@ class RingRecordingE2ETest {
         // Webhook (disabled)
         single {
             object : IndexWebhookApi {
-                override fun uploadIfEnabled(samples: ShortArray?, sampleRate: Int, recordingId: String, transcription: String?, recordedAt: Instant) {}
+                override fun uploadIfEnabled(
+                    samples: ShortArray?,
+                    sampleRate: Int,
+                    recordingId: String,
+                    transcription: String?,
+                    recordedAt: Instant,
+                    trigger: coredevices.ring.external.indexwebhook.IndexWebhookRecordingTrigger?,
+                ) {}
                 override val isEnabled: StateFlow<Boolean> = MutableStateFlow(false)
             }
         } bind IndexWebhookApi::class

--- a/experimental/src/androidInstrumentedTest/kotlin/coredevices/coreapp/ring/database/RecordingProcessingTaskButtonSequenceTest.kt
+++ b/experimental/src/androidInstrumentedTest/kotlin/coredevices/coreapp/ring/database/RecordingProcessingTaskButtonSequenceTest.kt
@@ -1,0 +1,70 @@
+package coredevices.coreapp.ring.database
+
+import androidx.room.Room
+import androidx.test.platform.app.InstrumentationRegistry
+import coredevices.indexai.data.entity.RingTransferInfo
+import coredevices.libindex.database.entity.RingTransfer
+import coredevices.libindex.database.entity.RingTransferStatus
+import coredevices.ring.data.entity.room.RecordingProcessingTaskEntity
+import coredevices.ring.data.entity.room.RecordingProcessingTaskType
+import coredevices.ring.database.room.RingDatabase
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+class RecordingProcessingTaskButtonSequenceTest {
+    private lateinit var db: RingDatabase
+
+    @Before
+    fun setUp() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        db = Room.inMemoryDatabaseBuilder<RingDatabase>(context.applicationContext)
+            .fallbackToDestructiveMigrationOnDowngrade(true)
+            .setQueryCoroutineContext(Dispatchers.IO)
+            .build()
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun latestKnownButtonSequenceSurvivesRetryTaskWithoutSequence() = runBlocking {
+        val transferId = db.ringTransferDao().insert(
+            RingTransfer(
+                recordingId = null,
+                recordingEntryId = null,
+                isCurrentIndexIteration = true,
+                transferInfo = RingTransferInfo(collectionStartIndex = 42),
+                status = RingTransferStatus.Completed,
+            )
+        )
+        val taskDao = db.recordingProcessingTaskDao()
+        taskDao.insertTask(audioTask(transferId, "double-click-hold"))
+        taskDao.insertTask(audioTask(transferId, null))
+
+        assertEquals(
+            "double-click-hold",
+            taskDao.getLatestButtonSequenceForTransfer(transferId),
+        )
+    }
+
+    @Test
+    fun unknownButtonSequenceRemainsUnknown() = runBlocking {
+        assertNull(db.recordingProcessingTaskDao().getLatestButtonSequenceForTransfer(999))
+    }
+
+    private fun audioTask(transferId: Long, buttonSequence: String?) =
+        RecordingProcessingTaskEntity(
+            type = RecordingProcessingTaskType.AudioRecording,
+            buttonSequence = buttonSequence,
+            transferId = transferId,
+            fileId = null,
+            transcription = null,
+        )
+}

--- a/experimental/src/androidInstrumentedTest/kotlin/coredevices/coreapp/ring/queue/RecordingProcessingQueueTest.kt
+++ b/experimental/src/androidInstrumentedTest/kotlin/coredevices/coreapp/ring/queue/RecordingProcessingQueueTest.kt
@@ -241,7 +241,14 @@ class RecordingProcessingQueueTest {
 
         single {
             object : IndexWebhookApi {
-                override fun uploadIfEnabled(samples: ShortArray?, sampleRate: Int, recordingId: String, transcription: String?, recordedAt: Instant) {}
+                override fun uploadIfEnabled(
+                    samples: ShortArray?,
+                    sampleRate: Int,
+                    recordingId: String,
+                    transcription: String?,
+                    recordedAt: Instant,
+                    trigger: coredevices.ring.external.indexwebhook.IndexWebhookRecordingTrigger?,
+                ) {}
                 override val isEnabled: StateFlow<Boolean> = MutableStateFlow(false)
             }
         } bind IndexWebhookApi::class

--- a/experimental/src/commonMain/kotlin/coredevices/ring/database/room/dao/RecordingProcessingTaskDao.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/database/room/dao/RecordingProcessingTaskDao.kt
@@ -10,6 +10,9 @@ import kotlin.time.Instant
 
 @Dao
 interface RecordingProcessingTaskDao {
+    @Query("SELECT buttonSequence FROM RecordingProcessingTaskEntity WHERE transferId = :transferId AND buttonSequence IS NOT NULL ORDER BY created DESC LIMIT 1")
+    suspend fun getLatestButtonSequenceForTransfer(transferId: Long): String?
+
     @Insert
     suspend fun insertTask(task: RecordingProcessingTaskEntity): Long
 

--- a/experimental/src/commonMain/kotlin/coredevices/ring/database/room/repository/RecordingProcessingTaskRepository.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/database/room/repository/RecordingProcessingTaskRepository.kt
@@ -15,6 +15,9 @@ class RecordingProcessingTaskRepository(
     private val dao: RecordingProcessingTaskDao
 ): QueueTaskRepository<RecordingProcessingTask> {
 
+    suspend fun getLatestButtonSequenceForTransfer(transferId: Long): String? =
+        dao.getLatestButtonSequenceForTransfer(transferId)
+
     private fun RecordingProcessingTask.toEntity(): RecordingProcessingTaskEntity {
         when (task) {
             is ProcessingTask.AudioRecording -> {

--- a/experimental/src/commonMain/kotlin/coredevices/ring/external/indexwebhook/INDEX_WEBHOOK_API.md
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/external/indexwebhook/INDEX_WEBHOOK_API.md
@@ -17,6 +17,7 @@ POST <your webhook URL>
 Content-Type: multipart/form-data; boundary=<uuid>
 <each user-configured header>
 X-Audio-Size: <byte count>  (when audio is included)
+X-Index-Trigger: single-click-hold | double-click-hold  (when known)
 ```
 
 ## Multipart Fields
@@ -57,6 +58,8 @@ Headers are fully user-configurable in the webhook settings — add as many name
 
 `X-Audio-Size` is still added automatically when audio is included (it carries the audio byte count) and cannot be overridden.
 
+`X-Index-Trigger` is added automatically to identify the ring gesture that started the recording. Its value is either `single-click-hold` or `double-click-hold`, allowing receivers to route the two actions differently. The gesture is persisted with the processing task and preserved when a failed recording is retried. For legacy tasks where the gesture is unknown, the header is omitted instead of defaulting to `single-click-hold`. It cannot be overridden by a user-configured header.
+
 > Migration note: users who previously configured an auth token have it automatically carried over as an `X-Widget-Token` header, preserving existing behaviour.
 
 ## Authentication
@@ -79,6 +82,7 @@ def receive():
     audio = request.files.get('audio')
     transcription = request.form.get('transcription')
     recorded_at = request.form.get('recordedAt')
+    trigger = request.headers.get('X-Index-Trigger')
 
     if audio:
         audio.save(f'/tmp/{audio.filename}')
@@ -88,6 +92,7 @@ def receive():
         print(f'Transcription: {transcription}')
 
     print(f'Recorded at: {recorded_at}')
+    print(f'Trigger: {trigger}')
     return 'OK', 200
 ```
 

--- a/experimental/src/commonMain/kotlin/coredevices/ring/external/indexwebhook/IndexWebhookApi.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/external/indexwebhook/IndexWebhookApi.kt
@@ -30,6 +30,7 @@ interface IndexWebhookApi {
      * @param recordingId Unique identifier for the recording (used in filename)
      * @param transcription Transcription text. Null when RecordingOnly mode.
      * @param recordedAt When the recording was actually made
+     * @param trigger Button gesture that started the recording
      */
     fun uploadIfEnabled(
         samples: ShortArray?,
@@ -37,8 +38,14 @@ interface IndexWebhookApi {
         recordingId: String,
         transcription: String?,
         recordedAt: Instant,
+        trigger: IndexWebhookRecordingTrigger?,
     )
     val isEnabled: StateFlow<Boolean>
+}
+
+enum class IndexWebhookRecordingTrigger(val headerValue: String) {
+    SingleClickHold("single-click-hold"),
+    DoubleClickHold("double-click-hold"),
 }
 
 /**
@@ -56,6 +63,7 @@ class IndexWebhookApiImpl(
     companion object {
         private val logger = Logger.withTag("IndexWebhookApi")
         private const val AUDIO_SIZE_HEADER = "X-Audio-Size"
+        private const val TRIGGER_HEADER = "X-Index-Trigger"
     }
 
     private val _isEnabled = MutableStateFlow(false)
@@ -77,6 +85,7 @@ class IndexWebhookApiImpl(
         recordingId: String,
         transcription: String?,
         recordedAt: Instant,
+        trigger: IndexWebhookRecordingTrigger?,
     ) {
         val url = webhookPreferences.webhookUrl.value
         if (url.isNullOrBlank()) return
@@ -107,7 +116,8 @@ class IndexWebhookApiImpl(
                     audioData = m4aData,
                     filename = "$recordingId.m4a",
                     transcription = transcriptionToSend,
-                    recordedAt = recordedAt
+                    recordedAt = recordedAt,
+                    trigger = trigger,
                 )
 
                 result.fold(
@@ -126,7 +136,8 @@ class IndexWebhookApiImpl(
         audioData: ByteArray?,
         filename: String,
         transcription: String?,
-        recordedAt: Instant
+        recordedAt: Instant,
+        trigger: IndexWebhookRecordingTrigger?,
     ): Result<Unit> {
         return try {
             val boundary = Uuid.random().toString()
@@ -142,7 +153,10 @@ class IndexWebhookApiImpl(
             )
 
             val response = client.post(url) {
-                headers.forEach { (name, value) -> header(name, value) }
+                headers
+                    .filterKeys { !it.equals(TRIGGER_HEADER, ignoreCase = true) }
+                    .forEach { (name, value) -> header(name, value) }
+                trigger?.let { header(TRIGGER_HEADER, it.headerValue) }
                 if (audioData != null) {
                     header(AUDIO_SIZE_HEADER, audioData.size.toString())
                 }

--- a/experimental/src/commonMain/kotlin/coredevices/ring/service/recordings/RecordingProcessingQueue.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/service/recordings/RecordingProcessingQueue.kt
@@ -609,9 +609,11 @@ class RecordingProcessingQueue(
             recordingEntryId = recordingEntryId,
             recordingEntityId = recordingId,
         )
+        val persistedButtonSequence = buttonSequence
+            ?: queueTaskRepository.getLatestButtonSequenceForTransfer(transferId)
         val task = ProcessingTask.AudioRecording(
             transferId = transferId,
-            buttonSequence = buttonSequence,
+            buttonSequence = persistedButtonSequence,
         )
         scheduleTask(
             RecordingProcessingTask(

--- a/experimental/src/commonMain/kotlin/coredevices/ring/service/recordings/button/IndexWebhookUploadRecordingOperation.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/service/recordings/button/IndexWebhookUploadRecordingOperation.kt
@@ -6,6 +6,7 @@ import coredevices.indexai.database.dao.RecordingEntryDao
 import coredevices.ring.external.indexwebhook.IndexWebhookApi
 import coredevices.ring.external.indexwebhook.IndexWebhookPayloadMode
 import coredevices.ring.external.indexwebhook.IndexWebhookPreferences
+import coredevices.ring.external.indexwebhook.IndexWebhookRecordingTrigger
 import coredevices.ring.service.recordings.RecordingProcessingQueue
 import coredevices.ring.storage.RecordingStorage
 import kotlinx.coroutines.sync.Mutex
@@ -29,7 +30,8 @@ class IndexWebhookUploadRecordingOperation(
     private val recordingStorage: RecordingStorage,
     private val decorated: RecordingOperation,
     private val fileId: String,
-    private val recordingId: Long
+    private val recordingId: Long,
+    private val trigger: IndexWebhookRecordingTrigger?,
 ): RecordingOperation, KoinComponent {
 
     companion object {
@@ -77,6 +79,6 @@ class IndexWebhookUploadRecordingOperation(
         val recordedAt = localRecordingDao.getRecording(recordingId)?.localTimestamp
             ?: Clock.System.now()
 
-        webhookApi.uploadIfEnabled(samples, sampleRate, fileId, transcription, recordedAt)
+        webhookApi.uploadIfEnabled(samples, sampleRate, fileId, transcription, recordedAt, trigger)
     }
 }

--- a/experimental/src/commonMain/kotlin/coredevices/ring/service/recordings/button/RecordingOperationFactory.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/service/recordings/button/RecordingOperationFactory.kt
@@ -13,6 +13,7 @@ import coredevices.ring.database.room.repository.ItemRepository
 import coredevices.ring.database.room.repository.McpSandboxRepository
 import coredevices.ring.external.indexwebhook.IndexWebhookApi
 import coredevices.ring.external.indexwebhook.IndexWebhookPreferences
+import coredevices.ring.external.indexwebhook.IndexWebhookRecordingTrigger
 import coredevices.ring.external.indexwebhook.IndexWebhookTrigger
 import coredevices.ring.service.ButtonPress
 import coredevices.ring.service.indexfeed.ItemFactory
@@ -42,6 +43,11 @@ class RecordingOperationFactory(
         sequence: List<ButtonPress>?
     ): RecordingOperation {
         val isDoubleClickHold = sequence == secondaryOperationSequence
+        val webhookTrigger = when {
+            isDoubleClickHold -> IndexWebhookRecordingTrigger.DoubleClickHold
+            sequence != null -> IndexWebhookRecordingTrigger.SingleClickHold
+            else -> null
+        }
         val inner = if (isDoubleClickHold) {
             createSecondaryOperation(
                 recordingId = recordingId,
@@ -65,6 +71,7 @@ class RecordingOperationFactory(
             recordingId = recordingId,
             fileId = fileId,
             isDoubleClickHold = isDoubleClickHold,
+            trigger = webhookTrigger,
             inner = inner,
         )
     }
@@ -73,6 +80,7 @@ class RecordingOperationFactory(
         recordingId: Long,
         fileId: String,
         isDoubleClickHold: Boolean,
+        trigger: IndexWebhookRecordingTrigger?,
         inner: RecordingOperation,
     ): RecordingOperation {
         val configured = !indexWebhookPreferences.webhookUrl.value.isNullOrBlank()
@@ -89,6 +97,7 @@ class RecordingOperationFactory(
             recordingStorage = recordingStorage,
             fileId = fileId,
             recordingId = recordingId,
+            trigger = trigger,
             decorated = inner,
         )
     }

--- a/experimental/src/commonTest/kotlin/coredevices/ring/external/indexwebhook/IndexWebhookRecordingTriggerTest.kt
+++ b/experimental/src/commonTest/kotlin/coredevices/ring/external/indexwebhook/IndexWebhookRecordingTriggerTest.kt
@@ -1,0 +1,18 @@
+package coredevices.ring.external.indexwebhook
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class IndexWebhookRecordingTriggerTest {
+    @Test
+    fun triggerHeaderValuesAreStable() {
+        assertEquals(
+            "single-click-hold",
+            IndexWebhookRecordingTrigger.SingleClickHold.headerValue,
+        )
+        assertEquals(
+            "double-click-hold",
+            IndexWebhookRecordingTrigger.DoubleClickHold.headerValue,
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- include the Index recording gesture in webhook requests as `X-Index-Trigger`
- send stable values `single-click-hold` and `double-click-hold`
- prevent user-configured headers from overriding the actual trigger
- document the header and receiving example

## Why

Webhook receivers currently get the recording and transcription but cannot tell which configured Index action triggered the request. Exposing the gesture lets integrations route single-click-and-hold and double-click-and-hold recordings to different workflows.

The app already computes this distinction in `RecordingOperationFactory`; this change carries it through the upload operation to the HTTP request.

## Testing

- added a common test that locks the two public header values
- checked every `IndexWebhookApi.uploadIfEnabled` implementation and call site
- `git diff --check` passes
- local Gradle execution could not configure the project because this machine has no Android SDK; upstream CI should exercise the full multiplatform build
