### PR TITLE
Intercept Pebble watchapp dictation into the Index Feed

### DIFF
--- a/experimental/src/commonMain/kotlin/coredevices/experimentalModule.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/experimentalModule.kt
@@ -68,6 +68,7 @@ import coredevices.ring.api.NenyaModel
 import coredevices.ring.service.RecordingBackgroundScope
 import coredevices.ring.service.RingPairing
 import coredevices.ring.service.RingSync
+import coredevices.ring.service.recordings.PebbleWatchappDictationSink
 import coredevices.ring.service.recordings.RecordingPreprocessor
 import coredevices.ring.service.recordings.RecordingProcessingQueue
 import coredevices.ring.service.recordings.RecordingProcessor
@@ -82,6 +83,7 @@ import coredevices.ring.util.trace.TraceSessionExporter
 import coredevices.ring.viewmodelModule
 import coredevices.util.CommonBuildKonfig
 import coredevices.util.PermissionRequester
+import coredevices.util.dictation.PebbleDictationSink
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
@@ -212,6 +214,7 @@ val experimentalModule = module {
     single { RecordingProcessingQueue(get(), get(), get(), get(), get(), get(), get(), get()) }
     singleOf(::RecordingOperationFactory)
     singleOf(::RealRecordingStorage) bind RecordingStorage::class
+    single { PebbleWatchappDictationSink(get(), get(), get()) } bind PebbleDictationSink::class
     singleOf(::DocumentEncryptor)
     singleOf(::EncryptionManager)
     singleOf(::RecordingPreprocessor)

--- a/experimental/src/commonMain/kotlin/coredevices/ring/database/Preferences.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/database/Preferences.kt
@@ -6,7 +6,6 @@ import coredevices.ring.agent.builtin_servlets.messaging.ApprovedBeeperContact
 import coredevices.ring.agent.builtin_servlets.notes.NoteProvider
 import coredevices.ring.agent.builtin_servlets.reminders.ReminderProvider
 import coredevices.ring.data.NoteShortcutType
-import coredevices.ring.service.recordings.PebbleWatchappDictationSink
 import coredevices.util.models.CactusSTTMode
 import kotlin.uuid.Uuid
 import kotlinx.coroutines.Dispatchers
@@ -156,7 +155,7 @@ class PreferencesImpl(private val settings: Settings): Preferences {
             ?.split(",")
             ?.mapNotNull { runCatching { Uuid.parse(it) }.getOrNull() }
             ?.toSet()
-            ?: setOf(PebbleWatchappDictationSink.TARGET_WATCHAPP_UUID) // seed: preserves Phase 1 behavior on upgrade
+            ?: emptySet()
     )
     override val indexFeedWatchappUuids = _indexFeedWatchappUuids.asStateFlow()
 
@@ -298,8 +297,11 @@ class PreferencesImpl(private val settings: Settings): Preferences {
     }
 
     override fun setIndexFeedWatchappUuids(uuids: Set<Uuid>) {
-        if (uuids.isEmpty()) settings.remove("index_feed_watchapp_uuids")
-        else settings.putString("index_feed_watchapp_uuids", uuids.joinToString(",") { it.toString() })
+        if (uuids.isEmpty()) {
+            settings.remove("index_feed_watchapp_uuids")
+        } else {
+            settings.putString("index_feed_watchapp_uuids", uuids.joinToString(",") { it.toString() })
+        }
         _indexFeedWatchappUuids.value = uuids
     }
 }

--- a/experimental/src/commonMain/kotlin/coredevices/ring/database/Preferences.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/database/Preferences.kt
@@ -6,7 +6,9 @@ import coredevices.ring.agent.builtin_servlets.messaging.ApprovedBeeperContact
 import coredevices.ring.agent.builtin_servlets.notes.NoteProvider
 import coredevices.ring.agent.builtin_servlets.reminders.ReminderProvider
 import coredevices.ring.data.NoteShortcutType
+import coredevices.ring.service.recordings.PebbleWatchappDictationSink
 import coredevices.util.models.CactusSTTMode
+import kotlin.uuid.Uuid
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -38,6 +40,8 @@ interface Preferences: BasePreferences {
      *  manual sync.
      */
     val lastBackupCount: StateFlow<Int?>
+    /** User-editable set of watchapp UUIDs accepted for dictation ingestion. */
+    val indexFeedWatchappUuids: StateFlow<Set<Uuid>>
 
     suspend fun setUseCactusAgent(useCactus: Boolean)
     suspend fun setUseCactusTranscription(useCactus: Boolean)
@@ -56,6 +60,7 @@ interface Preferences: BasePreferences {
     fun setEncryptionKeyFingerprint(fingerprint: String?)
     fun setLastWipedRing(id: String?)
     fun setLastBackupCount(count: Int?)
+    fun setIndexFeedWatchappUuids(uuids: Set<Uuid>)
 }
 
 class PreferencesImpl(private val settings: Settings): Preferences {
@@ -146,6 +151,14 @@ class PreferencesImpl(private val settings: Settings): Preferences {
         if (settings.hasKey("last_backup_count")) settings.getInt("last_backup_count", 0) else null
     )
     override val lastBackupCount = _lastBackupCount.asStateFlow()
+    private val _indexFeedWatchappUuids = MutableStateFlow(
+        settings.getStringOrNull("index_feed_watchapp_uuids")
+            ?.split(",")
+            ?.mapNotNull { runCatching { Uuid.parse(it) }.getOrNull() }
+            ?.toSet()
+            ?: setOf(PebbleWatchappDictationSink.TARGET_WATCHAPP_UUID) // seed: preserves Phase 1 behavior on upgrade
+    )
+    override val indexFeedWatchappUuids = _indexFeedWatchappUuids.asStateFlow()
 
     override suspend fun setUseCactusAgent(useCactus: Boolean) {
         withContext(Dispatchers.IO) {
@@ -282,6 +295,12 @@ class PreferencesImpl(private val settings: Settings): Preferences {
             settings.remove("last_backup_count")
         }
         _lastBackupCount.value = count
+    }
+
+    override fun setIndexFeedWatchappUuids(uuids: Set<Uuid>) {
+        if (uuids.isEmpty()) settings.remove("index_feed_watchapp_uuids")
+        else settings.putString("index_feed_watchapp_uuids", uuids.joinToString(",") { it.toString() })
+        _indexFeedWatchappUuids.value = uuids
     }
 }
 

--- a/experimental/src/commonMain/kotlin/coredevices/ring/service/recordings/PebbleWatchappDictationSink.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/service/recordings/PebbleWatchappDictationSink.kt
@@ -1,9 +1,12 @@
 package coredevices.ring.service.recordings
 
 import co.touchlab.kermit.Logger
+import coredevices.resampler.Resampler
 import coredevices.ring.database.Preferences
 import coredevices.ring.storage.RecordingStorage
 import coredevices.util.dictation.PebbleDictationSink
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import kotlin.uuid.Uuid
 
 class PebbleWatchappDictationSink(
@@ -14,6 +17,7 @@ class PebbleWatchappDictationSink(
 
     companion object {
         private val logger = Logger.withTag("PebbleWatchappDictationSink")
+        private const val TARGET_SAMPLE_RATE = 16000
     }
 
     override suspend fun canIngest(appUuid: Uuid): Boolean =
@@ -21,11 +25,38 @@ class PebbleWatchappDictationSink(
 
     override suspend fun ingest(appUuid: Uuid, pcm: ByteArray, sampleRateHz: Int) {
         val fileId = "pebble-watch-${Uuid.random()}"
-        logger.i {
-            "Ingesting ${pcm.size} bytes of dictation audio from watchapp $appUuid as " +
-                "$fileId (sampleRate=$sampleRateHz)"
+        val resampledPcm = withContext(Dispatchers.Default) {
+            if (sampleRateHz == TARGET_SAMPLE_RATE) {
+                pcm
+            } else {
+                Resampler(sampleRateHz, TARGET_SAMPLE_RATE).process(pcm.toShortArrayLe()).toByteArrayLe()
+            }
         }
-        recordingStorage.openRecordingSink(fileId, sampleRateHz, "audio/raw").use { it.write(pcm) }
+        logger.i {
+            "Ingesting ${resampledPcm.size} bytes of dictation audio from watchapp $appUuid as " +
+                "$fileId (sampleRate=$sampleRateHz -> $TARGET_SAMPLE_RATE)"
+        }
+        recordingStorage.openRecordingSink(fileId, TARGET_SAMPLE_RATE, "audio/raw").use { it.write(resampledPcm) }
         recordingProcessingQueue.queueLocalAudioProcessing(fileId)
     }
+}
+
+private fun ByteArray.toShortArrayLe(): ShortArray {
+    val samples = ShortArray(size / 2)
+    for (i in samples.indices) {
+        val lo = this[i * 2].toInt() and 0xFF
+        val hi = this[i * 2 + 1].toInt()
+        samples[i] = ((hi shl 8) or lo).toShort()
+    }
+    return samples
+}
+
+private fun ShortArray.toByteArrayLe(): ByteArray {
+    val bytes = ByteArray(size * 2)
+    for (i in indices) {
+        val s = this[i].toInt()
+        bytes[i * 2] = s.toByte()
+        bytes[i * 2 + 1] = (s shr 8).toByte()
+    }
+    return bytes
 }

--- a/experimental/src/commonMain/kotlin/coredevices/ring/service/recordings/PebbleWatchappDictationSink.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/service/recordings/PebbleWatchappDictationSink.kt
@@ -6,17 +6,6 @@ import coredevices.ring.storage.RecordingStorage
 import coredevices.util.dictation.PebbleDictationSink
 import kotlin.uuid.Uuid
 
-/**
- * [PebbleDictationSink] that feeds dictation audio from one specific Pebble watchapp into the
- * same ring feed ingestion pipeline phone-microphone recordings use (`RecordingProcessingQueue`),
- * bypassing normal ASR entirely.
- *
- * Stage 1 (MVP): the target watchapp is a hardcoded UUID constant, matching the
- * `pebble-index-note` demo watchapp (see `pebble-index-note/package.json`). See
- * `specs/pebble-dictation-audio-index-feed-intercept.md` for the planned evolution to a
- * user-editable preference and then a picker, neither of which requires touching this class's
- * ingestion logic.
- */
 class PebbleWatchappDictationSink(
     private val recordingStorage: RecordingStorage,
     private val recordingProcessingQueue: RecordingProcessingQueue,
@@ -25,9 +14,6 @@ class PebbleWatchappDictationSink(
 
     companion object {
         private val logger = Logger.withTag("PebbleWatchappDictationSink")
-
-        /** Seed/default value only now: UUID of the production pebble-index-note watchapp. */
-        val TARGET_WATCHAPP_UUID: Uuid = Uuid.parse("049e694d-7d8f-4615-92aa-b77163a174c8")
     }
 
     override suspend fun canIngest(appUuid: Uuid): Boolean =

--- a/experimental/src/commonMain/kotlin/coredevices/ring/service/recordings/PebbleWatchappDictationSink.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/service/recordings/PebbleWatchappDictationSink.kt
@@ -1,0 +1,45 @@
+package coredevices.ring.service.recordings
+
+import co.touchlab.kermit.Logger
+import coredevices.ring.database.Preferences
+import coredevices.ring.storage.RecordingStorage
+import coredevices.util.dictation.PebbleDictationSink
+import kotlin.uuid.Uuid
+
+/**
+ * [PebbleDictationSink] that feeds dictation audio from one specific Pebble watchapp into the
+ * same ring feed ingestion pipeline phone-microphone recordings use (`RecordingProcessingQueue`),
+ * bypassing normal ASR entirely.
+ *
+ * Stage 1 (MVP): the target watchapp is a hardcoded UUID constant, matching the
+ * `pebble-index-note` demo watchapp (see `pebble-index-note/package.json`). See
+ * `specs/pebble-dictation-audio-index-feed-intercept.md` for the planned evolution to a
+ * user-editable preference and then a picker, neither of which requires touching this class's
+ * ingestion logic.
+ */
+class PebbleWatchappDictationSink(
+    private val recordingStorage: RecordingStorage,
+    private val recordingProcessingQueue: RecordingProcessingQueue,
+    private val preferences: Preferences,
+) : PebbleDictationSink {
+
+    companion object {
+        private val logger = Logger.withTag("PebbleWatchappDictationSink")
+
+        /** Seed/default value only now: UUID of the production pebble-index-note watchapp. */
+        val TARGET_WATCHAPP_UUID: Uuid = Uuid.parse("049e694d-7d8f-4615-92aa-b77163a174c8")
+    }
+
+    override suspend fun canIngest(appUuid: Uuid): Boolean =
+        appUuid in preferences.indexFeedWatchappUuids.value
+
+    override suspend fun ingest(appUuid: Uuid, pcm: ByteArray, sampleRateHz: Int) {
+        val fileId = "pebble-watch-${Uuid.random()}"
+        logger.i {
+            "Ingesting ${pcm.size} bytes of dictation audio from watchapp $appUuid as " +
+                "$fileId (sampleRate=$sampleRateHz)"
+        }
+        recordingStorage.openRecordingSink(fileId, sampleRateHz, "audio/raw").use { it.write(pcm) }
+        recordingProcessingQueue.queueLocalAudioProcessing(fileId)
+    }
+}

--- a/experimental/src/commonMain/kotlin/coredevices/ring/ui/screens/settings/IndexSettings.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/ui/screens/settings/IndexSettings.kt
@@ -927,7 +927,7 @@ fun NoteShortcutDialog(
 }
 
 @Composable
-private fun IndexFeedWatchappsDialog(
+fun IndexFeedWatchappsDialog(
     selectedUuids: Set<Uuid>,
     onSelectionChanged: (Set<Uuid>) -> Unit,
     onDismissRequest: () -> Unit,

--- a/experimental/src/commonMain/kotlin/coredevices/ring/ui/screens/settings/IndexSettings.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/ui/screens/settings/IndexSettings.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -37,6 +38,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -117,6 +119,8 @@ import coredevices.util.granted
 import coredevices.util.isAndroid
 import coredevices.util.isIOS
 import coredevices.util.rememberUiContext
+import io.rebble.libpebblecommon.connection.LibPebble
+import io.rebble.libpebblecommon.locker.AppType
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.imageResource
@@ -124,6 +128,7 @@ import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
+import kotlin.uuid.Uuid
 import coreapp.util.generated.resources.Res as UtilRes
 
 // openUri throws if nothing can handle the link (no browser, DPC policy);
@@ -147,6 +152,8 @@ fun IndexSettings(coreNav: CoreNav) {
     val showSecondaryModeDialog by viewModel.showSecondaryModeDialog.collectAsState()
     val showNoteShortcutDialog by viewModel.showNoteShortcutDialog.collectAsState()
     val autoDismissActionNotifications by viewModel.autoDismissActionNotifications.collectAsState()
+    val showIndexFeedWatchappsDialog by viewModel.showIndexFeedWatchappsDialog.collectAsState()
+    val indexFeedWatchappUuids by viewModel.indexFeedWatchappUuids.collectAsState()
     val platform = koinInject<Platform>()
     val webhookUrl by webhookViewModel.webhookUrl.collectAsState()
     val webhookIsLinked = !webhookUrl.isNullOrBlank()
@@ -217,6 +224,13 @@ fun IndexSettings(coreNav: CoreNav) {
             onDismissRequest = {
                 viewModel.closeNoteShortcutDialog()
             }
+        )
+    }
+    if (showIndexFeedWatchappsDialog) {
+        IndexFeedWatchappsDialog(
+            selectedUuids = indexFeedWatchappUuids,
+            onSelectionChanged = viewModel::setIndexFeedWatchappUuids,
+            onDismissRequest = viewModel::closeIndexFeedWatchappsDialog,
         )
     }
     if (webhookDialogOpen) {
@@ -587,6 +601,23 @@ fun IndexSettings(coreNav: CoreNav) {
                         headlineContent = { Text("Ring Sync Inspector") }
                     )
                 }
+                item {
+                    ListItem(
+                        modifier = Modifier.clickable {
+                            viewModel.showIndexFeedWatchappsDialog()
+                        },
+                        headlineContent = { Text("Index Feed Watchapps") },
+                        supportingContent = {
+                            Text(
+                                when (indexFeedWatchappUuids.size) {
+                                    0 -> "None selected"
+                                    1 -> "1 watchapp"
+                                    else -> "${indexFeedWatchappUuids.size} watchapps"
+                                }
+                            )
+                        }
+                    )
+                }
             }
             item {
                 Spacer(Modifier.height(32.dp))
@@ -889,6 +920,69 @@ fun NoteShortcutDialog(
                     )
                     Spacer(Modifier.width(8.dp))
                     Text(label)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun IndexFeedWatchappsDialog(
+    selectedUuids: Set<Uuid>,
+    onSelectionChanged: (Set<Uuid>) -> Unit,
+    onDismissRequest: () -> Unit,
+) {
+    val libPebble = koinInject<LibPebble>()
+    val locker by libPebble.getLocker(AppType.Watchapp, null, 200).collectAsState(emptyList())
+    // Seed from the full passed-in selection (not filtered to the current locker
+    // snapshot) so a UUID for a temporarily-uninstalled app survives a round-trip.
+    var target by remember { mutableStateOf(selectedUuids) }
+
+    M3Dialog(
+        onDismissRequest = onDismissRequest,
+        title = { Text("Index Feed Watchapps") },
+        buttons = {
+            TextButton(onClick = onDismissRequest) {
+                Text("Cancel")
+            }
+            TextButton(
+                onClick = {
+                    onSelectionChanged(target)
+                    onDismissRequest()
+                }
+            ) {
+                Text("Save")
+            }
+        }
+    ) {
+        if (locker.isEmpty()) {
+            Text("Connect a watch to see installed apps")
+        } else {
+            LazyColumn(
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.heightIn(max = 400.dp)
+            ) {
+                items(locker, key = { it.properties.id }) { entry ->
+                    val checked = entry.properties.id in target
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable {
+                                target = if (checked) {
+                                    target - entry.properties.id
+                                } else {
+                                    target + entry.properties.id
+                                }
+                            }
+                    ) {
+                        Checkbox(
+                            checked = checked,
+                            onCheckedChange = null
+                        )
+                        Spacer(Modifier.width(8.dp))
+                        Text(entry.properties.title)
+                    }
                 }
             }
         }

--- a/experimental/src/commonMain/kotlin/coredevices/ring/ui/screens/settings/IndexSettings.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/ui/screens/settings/IndexSettings.kt
@@ -934,8 +934,8 @@ fun IndexFeedWatchappsDialog(
 ) {
     val libPebble = koinInject<LibPebble>()
     val locker by libPebble.getLocker(AppType.Watchapp, null, 200).collectAsState(emptyList())
-    // Seed from the full passed-in selection (not filtered to the current locker
-    // snapshot) so a UUID for a temporarily-uninstalled app survives a round-trip.
+    // Seeding from the stored selection - rather than the locker snapshot - lets a
+    // temporarily-uninstalled app's UUID survive a round-trip through this dialog.
     var target by remember { mutableStateOf(selectedUuids) }
 
     M3Dialog(

--- a/experimental/src/commonMain/kotlin/coredevices/ring/ui/viewmodel/SettingsViewModel.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/ui/viewmodel/SettingsViewModel.kt
@@ -287,7 +287,9 @@ class SettingsViewModel(
         preferences.setNoteShortcut(shortcut)
     }
 
-    fun setIndexFeedWatchappUuids(uuids: Set<Uuid>) = preferences.setIndexFeedWatchappUuids(uuids)
+    fun setIndexFeedWatchappUuids(uuids: Set<Uuid>) {
+        preferences.setIndexFeedWatchappUuids(uuids)
+    }
 
     fun showIndexFeedWatchappsDialog() {
         _showIndexFeedWatchappsDialog.value = true

--- a/experimental/src/commonMain/kotlin/coredevices/ring/ui/viewmodel/SettingsViewModel.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/ui/viewmodel/SettingsViewModel.kt
@@ -76,6 +76,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlin.time.Clock
 import kotlin.time.Instant
+import kotlin.uuid.Uuid
 
 @Serializable
 private data class BackupManifest(
@@ -139,6 +140,9 @@ class SettingsViewModel(
     val showNoteShortcutDialog = _showNoteShortcutDialog.asStateFlow()
     val noteShortcut = preferences.noteShortcut
     val autoDismissActionNotifications = preferences.autoDismissActionNotifications
+    private val _showIndexFeedWatchappsDialog = MutableStateFlow(false)
+    val showIndexFeedWatchappsDialog = _showIndexFeedWatchappsDialog.asStateFlow()
+    val indexFeedWatchappUuids = preferences.indexFeedWatchappUuids
     private val currentRing = indexDeviceManager.rings.map {
         it.firstOrNull { ring -> ring is KnownIndexDevice }
     }
@@ -281,6 +285,16 @@ class SettingsViewModel(
 
     fun setNoteShortcut(shortcut: NoteShortcutType) {
         preferences.setNoteShortcut(shortcut)
+    }
+
+    fun setIndexFeedWatchappUuids(uuids: Set<Uuid>) = preferences.setIndexFeedWatchappUuids(uuids)
+
+    fun showIndexFeedWatchappsDialog() {
+        _showIndexFeedWatchappsDialog.value = true
+    }
+
+    fun closeIndexFeedWatchappsDialog() {
+        _showIndexFeedWatchappsDialog.value = false
     }
 
     fun showContactsDialog() {

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/connection/endpointmanager/audio/VoiceSessionManager.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/connection/endpointmanager/audio/VoiceSessionManager.kt
@@ -120,7 +120,7 @@ class VoiceSessionManager(
                     ))
                     return@collectLatest
                 }
-                if (transcriptionProvider.canServeSession()) {
+                if (transcriptionProvider.canServeSession(setupRequest.appUuid)) {
                     voiceService.send(makeSetupResult(
                         sessionType = setupRequest.sessionType,
                         result = Result.Success,
@@ -143,7 +143,8 @@ class VoiceSessionManager(
                     transcriptionProvider.transcribe(
                         setupRequest.encoderInfo,
                         audioFrameFlow,
-                        isNotificationReply = setupRequest.appUuid == Uuid.NIL || setupRequest.appUuid == SystemAppIDs.NOTIFICATIONS_APP_UUID
+                        isNotificationReply = setupRequest.appUuid == Uuid.NIL || setupRequest.appUuid == SystemAppIDs.NOTIFICATIONS_APP_UUID,
+                        appUuid = setupRequest.appUuid,
                     )
                 } catch (e: CancellationException) {
                     logger.d { "Voice session cancelled" }

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/voice/TranscriptionProvider.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/voice/TranscriptionProvider.kt
@@ -12,16 +12,11 @@ interface TranscriptionProvider {
     ): TranscriptionResult
     suspend fun canServeSession(): Boolean
 
-    /**
-     * [appUuid]-aware overloads, defaulting to the app-agnostic behavior above. Implementations
-     * that need to special-case a specific originating watchapp (e.g. diverting its audio away
-     * from ASR entirely) override these instead.
-     */
     suspend fun transcribe(
         encoderInfo: VoiceEncoderInfo,
         audioFrames: Flow<UByteArray>,
         isNotificationReply: Boolean,
-        appUuid: Uuid,
+        appUuid: Uuid
     ): TranscriptionResult = transcribe(encoderInfo, audioFrames, isNotificationReply)
 
     suspend fun canServeSession(appUuid: Uuid): Boolean = canServeSession()

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/voice/TranscriptionProvider.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/voice/TranscriptionProvider.kt
@@ -2,6 +2,7 @@ package io.rebble.libpebblecommon.voice
 
 import kotlinx.coroutines.flow.Flow
 import kotlin.time.Duration.Companion.seconds
+import kotlin.uuid.Uuid
 
 interface TranscriptionProvider {
     suspend fun transcribe(
@@ -10,6 +11,20 @@ interface TranscriptionProvider {
         isNotificationReply: Boolean
     ): TranscriptionResult
     suspend fun canServeSession(): Boolean
+
+    /**
+     * [appUuid]-aware overloads, defaulting to the app-agnostic behavior above. Implementations
+     * that need to special-case a specific originating watchapp (e.g. diverting its audio away
+     * from ASR entirely) override these instead.
+     */
+    suspend fun transcribe(
+        encoderInfo: VoiceEncoderInfo,
+        audioFrames: Flow<UByteArray>,
+        isNotificationReply: Boolean,
+        appUuid: Uuid,
+    ): TranscriptionResult = transcribe(encoderInfo, audioFrames, isNotificationReply)
+
+    suspend fun canServeSession(appUuid: Uuid): Boolean = canServeSession()
 }
 
 /**

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/services/STTRouter.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/services/STTRouter.kt
@@ -27,10 +27,9 @@ import kotlin.uuid.Uuid
  * for `RebbleFirst`/`RebbleFallback` modes (which buffer Speex frames so they can be replayed
  * across both backends).
  *
- * When [dictationSink] is set and matches a session's `appUuid`, that session is diverted away
- * from ASR entirely: its Speex audio is decoded (reusing [decodeSpeex]) and handed to the sink
- * instead of being transcribed, and this class reports [TranscriptionResult.Success] with no
- * words so the watch gets its normal end-of-session ack with no transcript.
+ * When [dictationSink] matches a session's `appUuid`, [transcribe] reports
+ * [TranscriptionResult.Success] with no words instead of transcribing, so the watch still gets
+ * its normal end-of-session ack with no transcript.
  */
 class STTRouter(
     private val cactus: HybridTranscription,
@@ -74,7 +73,12 @@ class STTRouter(
             require(encoderInfo is VoiceEncoderInfo.Speex) {
                 "Pebble dictation intercept only supports Speex encoding, got ${encoderInfo::class.simpleName}"
             }
-            val pcm = decodeSpeex(encoderInfo, audioFrames.toList())
+            val frames = audioFrames.toList()
+            if (frames.isEmpty()) {
+                return TranscriptionResult.Success(emptyList())
+            }
+            val pcm = decodeSpeex(encoderInfo, frames)
+            logger.i { "Diverting dictation for app $appUuid to ring feed (${pcm.size} PCM bytes @ ${encoderInfo.sampleRate}Hz)" }
             dictationSink.ingest(appUuid, pcm, encoderInfo.sampleRate.toInt())
             return TranscriptionResult.Success(emptyList())
         }

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/services/STTRouter.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/services/STTRouter.kt
@@ -4,6 +4,7 @@ import co.touchlab.kermit.Logger
 import coredevices.speex.SpeexCodec
 import coredevices.speex.SpeexDecodeResult
 import coredevices.util.CoreConfigFlow
+import coredevices.util.dictation.PebbleDictationSink
 import coredevices.util.models.CactusSTTMode
 import coredevices.util.transcription.CactusTranscriptionService
 import coredevices.util.transcription.TranscriptionException
@@ -18,18 +19,25 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.withContext
+import kotlin.uuid.Uuid
 
 /**
  * Mode-aware [TranscriptionProvider] dispatching between [HybridTranscription] (cloud/local via
  * Cactus + WisprFlow) and [RebbleAsrTranscription] (Rebble's ASR). Owns fallback orchestration
  * for `RebbleFirst`/`RebbleFallback` modes (which buffer Speex frames so they can be replayed
  * across both backends).
+ *
+ * When [dictationSink] is set and matches a session's `appUuid`, that session is diverted away
+ * from ASR entirely: its Speex audio is decoded (reusing [decodeSpeex]) and handed to the sink
+ * instead of being transcribed, and this class reports [TranscriptionResult.Success] with no
+ * words so the watch gets its normal end-of-session ack with no transcript.
  */
 class STTRouter(
     private val cactus: HybridTranscription,
     private val rebble: RebbleAsrTranscription,
     private val cactusService: CactusTranscriptionService,
     private val coreConfigFlow: CoreConfigFlow,
+    private val dictationSink: PebbleDictationSink? = null,
 ) : TranscriptionProvider {
     companion object {
         private val logger = Logger.withTag("STTRouter")
@@ -48,6 +56,29 @@ class STTRouter(
                 rebble.isAvailable() || cactus.canServeSession()
             else -> cactus.canServeSession()
         }
+    }
+
+    override suspend fun canServeSession(appUuid: Uuid): Boolean {
+        if (dictationSink?.canIngest(appUuid) == true) return true
+        return canServeSession()
+    }
+
+    @OptIn(ExperimentalUnsignedTypes::class)
+    override suspend fun transcribe(
+        encoderInfo: VoiceEncoderInfo,
+        audioFrames: Flow<UByteArray>,
+        isNotificationReply: Boolean,
+        appUuid: Uuid,
+    ): TranscriptionResult {
+        if (dictationSink?.canIngest(appUuid) == true) {
+            require(encoderInfo is VoiceEncoderInfo.Speex) {
+                "Pebble dictation intercept only supports Speex encoding, got ${encoderInfo::class.simpleName}"
+            }
+            val pcm = decodeSpeex(encoderInfo, audioFrames.toList())
+            dictationSink.ingest(appUuid, pcm, encoderInfo.sampleRate.toInt())
+            return TranscriptionResult.Success(emptyList())
+        }
+        return transcribe(encoderInfo, audioFrames, isNotificationReply)
     }
 
     @OptIn(ExperimentalUnsignedTypes::class)

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/watchModule.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/watchModule.kt
@@ -229,6 +229,7 @@ val watchModule = module {
             rebble = get(),
             cactusService = get(),
             coreConfigFlow = get(),
+            dictationSink = getOrNull(),
         )
     } bind TranscriptionProvider::class
 

--- a/util/src/commonMain/kotlin/coredevices/util/dictation/PebbleDictationSink.kt
+++ b/util/src/commonMain/kotlin/coredevices/util/dictation/PebbleDictationSink.kt
@@ -2,13 +2,6 @@ package coredevices.util.dictation
 
 import kotlin.uuid.Uuid
 
-/**
- * Sink for dictation audio originating from one specific Pebble watchapp, injected into a
- * `TranscriptionProvider` implementation so it can divert that app's sessions away from normal
- * ASR and into another ingestion pipeline instead. Lives in `:util` - the one module both the
- * caller (`:pebble`) and the implementation (`:experimental`) already depend on - so neither
- * module needs a new dependency edge to the other.
- */
 interface PebbleDictationSink {
     suspend fun canIngest(appUuid: Uuid): Boolean
     suspend fun ingest(appUuid: Uuid, pcm: ByteArray, sampleRateHz: Int)

--- a/util/src/commonMain/kotlin/coredevices/util/dictation/PebbleDictationSink.kt
+++ b/util/src/commonMain/kotlin/coredevices/util/dictation/PebbleDictationSink.kt
@@ -1,0 +1,15 @@
+package coredevices.util.dictation
+
+import kotlin.uuid.Uuid
+
+/**
+ * Sink for dictation audio originating from one specific Pebble watchapp, injected into a
+ * `TranscriptionProvider` implementation so it can divert that app's sessions away from normal
+ * ASR and into another ingestion pipeline instead. Lives in `:util` - the one module both the
+ * caller (`:pebble`) and the implementation (`:experimental`) already depend on - so neither
+ * module needs a new dependency edge to the other.
+ */
+interface PebbleDictationSink {
+    suspend fun canIngest(appUuid: Uuid): Boolean
+    suspend fun ingest(appUuid: Uuid, pcm: ByteArray, sampleRateHz: Int)
+}


### PR DESCRIPTION
Closes coredevices/mobileapp#264

## Summary

When dictation audio arrives from a user-selected Pebble watchapp, the phone skips
normal transcription and instead feeds the decoded audio into the same pipeline
phone-mic recordings already use to become Index ring feed items. The watch still
gets its normal end-of-session ack, just with no transcript. Which watchapps are
selected is a user-editable set, not a compile-time constant.

## UI

Index Settings (debug section) gains an "Index Feed Watchapps" row showing the
current selection count. Tapping it opens a checkbox dialog of installed watchapps
(from `LibPebble.getLocker()`); changes save immediately. A watchapp that's since
been uninstalled stays selected instead of dropping out, so switching between debug
and release builds of the same app doesn't require re-picking it. No watch connected
→ empty-state message instead of a blank list.

## Design notes

- `PebbleDictationSink` lives in `:util` so `:pebble` (decoder) and `:experimental`
  (ring feed) stay sibling modules with no new dependency edge either way.
- Allowlist starts empty; nothing is intercepted until the user opts in.
- Decoded PCM is resampled to 16kHz (reusing `RingSync`'s `Resampler`) before
  ingestion, since the watch's native Speex rate isn't guaranteed to be 16kHz and
  the Ring pipeline expects that format.

## Testing

- `./gradlew :composeApp:assembleDebug` + existing unit tests pass.
- Verified end-to-end on real hardware: Android + a physical Pebble Time 2 running
  a debug build of [`pebble-index-note`](https://github.com/Kaysera/pebble-index-note) (which is a demo app I coded just for the purpose of this PR). Produces a real Index feed item that is later classified by the intent model and audio that can be listened.
- Verified with local STT + local Index model only; cloud not testable from a dev build (no login).

## Known follow-ups

- No automated test for this path yet (STTRouter intercept branch, or the new
  resample/byte-conversion logic).
- No guard on decode+write time vs. `PEBBLE_FW_TRANSCRIPTION_TIMEOUT` (~15s).
- Cancellation mid-intercept isn't specifically exercised.

## AI Usage

Claude has been used to help me understand the codebase and program the feature in a way that is coherent with the existing code. I'm a Python programmer and it's been 5 years since I last touched Kotlin so I have needed some help there. However, the design decisions and structure are mine. If they clash with the app design, are too complex and difficult to maintain, or introduce too much noise, I'm willing to work on this simplifying the feature and aligning it to the app as much as I can. 

