### PR TITLE
Android: preserve cleartext support in Network Security Config

### DIFF
--- a/androidApp/src/androidTest/kotlin/coredevices/coreapp/network/NetworkSecurityConfigTest.kt
+++ b/androidApp/src/androidTest/kotlin/coredevices/coreapp/network/NetworkSecurityConfigTest.kt
@@ -1,0 +1,18 @@
+package coredevices.coreapp.network
+
+import android.security.NetworkSecurityPolicy
+import androidx.test.filters.SdkSuppress
+import org.junit.Test
+import kotlin.test.assertTrue
+
+class NetworkSecurityConfigTest {
+    @Test
+    @SdkSuppress(minSdkVersion = 24)
+    fun cleartextTrafficIsPermittedForNonLoopbackHosts() {
+        assertTrue(
+            NetworkSecurityPolicy.getInstance()
+                .isCleartextTrafficPermitted("192.0.2.1"),
+            "The Network Security Config must preserve the manifest's cleartext opt-in",
+        )
+    }
+}

--- a/androidApp/src/main/res/xml/network_security_config.xml
+++ b/androidApp/src/main/res/xml/network_security_config.xml
@@ -5,9 +5,13 @@
   default, so PKJS apps connecting to self-hosted servers with a self-signed or
   private-CA cert (e.g. Home Assistant over wss://) fail to connect even after
   the user installs and trusts the cert on their device.
+
+  Keep the manifest's existing cleartext behavior for user-configured HTTP
+  endpoints. On Android 7.0 and later, once a Network Security Config is
+  present, Android ignores android:usesCleartextTraffic on the application.
 -->
 <network-security-config>
-    <base-config>
+    <base-config cleartextTrafficPermitted="true">
         <trust-anchors>
             <certificates src="system" />
             <certificates src="user" />


### PR DESCRIPTION
## Summary

- Fix Android rejecting user-configured non-loopback HTTP endpoints, which prevents Index webhooks from reaching otherwise accessible servers.
- Preserve the app manifest's explicit cleartext opt-in after the addition of a Network Security Config.
- Keep trusting both system and user-installed CA certificates.
- Add an Android instrumentation regression test for non-loopback cleartext hosts.

## Background

PR #248 added a Network Security Config so PKJS HTTPS/WSS connections can trust user-installed CA certificates. On Android 7.0 and later, once an app supplies a Network Security Config, `android:usesCleartextTraffic` is ignored. Because the new `base-config` did not explicitly allow cleartext traffic, Android began rejecting non-loopback HTTP endpoints before a socket was opened even though the manifest still declares `android:usesCleartextTraffic="true"`. If plain HTTP is intentionally unsupported for Index webhooks, the configuration UI should reject those URLs rather than accepting them and silently blocking the request at runtime.

This preserves the policy already expressed by the manifest rather than introducing a new cleartext policy. The system and user trust anchors added by #248 remain unchanged.

This is an app-wide policy fix rather than webhook-specific handling: the same base policy applies to other user-configured endpoints, including PKJS connections. Feature-specific HTTPS validation, where required, remains separate from Android's base network policy.

## Reproduction

Reproduced with Pebble 1.8.0.6 on a Pixel 9 Pro running Android 17:

- An Index webhook to `http://127.0.0.1:8388/index` reaches the loopback listener.
- A manual POST from the same phone to a non-loopback tailnet HTTP endpoint succeeds.
- An Index webhook to that same non-loopback endpoint never reaches the listener.

## Testing

- `./gradlew :androidApp:assembleDebug testDebugUnitTest testAndroidHostTest jvmTest lintDebug`
- `./gradlew :androidApp:compileDebugAndroidTestKotlin`
- `./gradlew :androidApp:assembleDebugAndroidTest`
- Inspected the packaged `res/xml/network_security_config.xml` with `aapt2`; the base policy contains `cleartextTrafficPermitted=true` and retains both trust anchors.

## AI disclosure

AI was used to assist with understanding the code, diagnosis, test drafting, PR wording, and analyzing all your existing PRs to make sure I'm not doing anything profoundly stupid. I reviewed the changes and understand why the Network Security Config must explicitly preserve the manifest's cleartext opt-in. [Human attention requires human effort](https://tombedor.dev/human-attention-and-human-effort/).