### PR TITLE
Make firmware sideloading scriptable over adb

### DIFF
--- a/pebble/src/androidMain/AndroidManifest.xml
+++ b/pebble/src/androidMain/AndroidManifest.xml
@@ -5,6 +5,14 @@
     <application>
         <receiver android:name=".ui.TestActionReceiver" android:exported="false" />
         <receiver android:name="coredevices.pebble.firmware.UpdateActionReceiver" android:exported="false" />
+        <receiver
+            android:name="coredevices.pebble.firmware.FirmwareSideloadReceiver"
+            android:exported="true"
+            android:permission="android.permission.DUMP">
+            <intent-filter>
+                <action android:name="coredevices.pebble.SIDELOAD_FIRMWARE" />
+            </intent-filter>
+        </receiver>
 
         <provider
             android:authorities="coredevices.coreapp.pebblekit"

--- a/pebble/src/androidMain/kotlin/coredevices/pebble/firmware/FirmwareSideloadReceiver.kt
+++ b/pebble/src/androidMain/kotlin/coredevices/pebble/firmware/FirmwareSideloadReceiver.kt
@@ -1,0 +1,59 @@
+package coredevices.pebble.firmware
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import co.touchlab.kermit.Logger
+import com.russhwolf.settings.Settings
+import coredevices.pebble.PebbleDeepLinkHandler
+import coredevices.pebble.ui.showDebugOptions
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import kotlinx.io.files.Path
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.get
+import java.io.File
+
+private const val ACTION_SIDELOAD_FIRMWARE = "coredevices.pebble.SIDELOAD_FIRMWARE"
+private const val EXTRA_PATH = "path"
+
+class FirmwareSideloadReceiver : BroadcastReceiver(), KoinComponent {
+    private val logger = Logger.withTag("FirmwareSideloadReceiver")
+
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action != ACTION_SIDELOAD_FIRMWARE) {
+            return
+        }
+        val pathExtra = intent.getStringExtra(EXTRA_PATH)
+        if (pathExtra == null) {
+            logger.w { "Ignoring sideload broadcast: missing \"$EXTRA_PATH\" extra" }
+            return
+        }
+        val pendingResult = goAsync()
+        GlobalScope.launch(Dispatchers.IO) {
+            try {
+                if (!get<Settings>().showDebugOptions()) {
+                    logger.w { "Ignoring sideload broadcast: debug options are disabled" }
+                    get<PebbleDeepLinkHandler>().showMessage(
+                        "Sideload ignored: turn on Show debug options in settings first"
+                    )
+                    return@launch
+                }
+                val file = if (pathExtra.startsWith("/")) {
+                    File(pathExtra)
+                } else {
+                    File(context.externalCacheDir, pathExtra)
+                }
+                if (!file.isFile) {
+                    logger.w { "Ignoring sideload broadcast: ${file.absolutePath} not found" }
+                    return@launch
+                }
+                logger.i { "Sideload broadcast for ${file.absolutePath}" }
+                get<PebbleDeepLinkHandler>().sideloadFirmware(Path(file.absolutePath))
+            } finally {
+                pendingResult.finish()
+            }
+        }
+    }
+}

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/PebbleDeepLinkHandler.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/PebbleDeepLinkHandler.kt
@@ -51,6 +51,8 @@ interface PebbleDeepLinkHandler {
     fun consumeRequestIndexCompanion()
     fun confirmPendingFirmwareSideload()
     fun dismissPendingFirmwareSideload()
+    fun sideloadFirmware(file: Path)
+    fun showMessage(message: String)
     fun handle(uri: Uri?): Boolean
 
     /** Show a navbar tab on the watch home screen (same mechanism as pebble://navbar links). */
@@ -233,7 +235,11 @@ class RealPebbleDeepLinkHandler(
         SystemFileSystem.delete(pending.file, mustExist = false)
     }
 
-    private fun sideloadFirmware(file: Path) {
+    override fun showMessage(message: String) {
+        _snackBarMessages.tryEmit(message)
+    }
+
+    override fun sideloadFirmware(file: Path) {
         GlobalScope.launch {
             val watches = withTimeoutOrNull(CONNECTED_WATCH_TIMEOUT) {
                 libPebble.watches

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/PreviewUtil.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/PreviewUtil.kt
@@ -76,6 +76,7 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.runBlocking
+import kotlinx.io.files.Path
 import kotlinx.serialization.json.Json
 import org.koin.compose.KoinApplication
 import org.koin.core.module.Module
@@ -346,6 +347,8 @@ private fun fakePebbleModule(appContext: AppContext) = module {
         override fun consumeRequestIndexCompanion() {}
         override fun confirmPendingFirmwareSideload() {}
         override fun dismissPendingFirmwareSideload() {}
+        override fun sideloadFirmware(file: Path) {}
+        override fun showMessage(message: String) {}
         override fun handle(uri: Uri?): Boolean = true
         override fun navigateToTab(route: NavBarRoute) {}
     }


### PR DESCRIPTION
Flashing a development build meant driving the phone UI by hand, which does not fit into a build script. This adds an adb-only broadcast that takes the same sideload.

Builds on the sideload flow from coredevices/mobileapp#326.

`FirmwareSideloadReceiver` takes a `coredevices.pebble.SIDELOAD_FIRMWARE` broadcast with a `path` extra, and starts the same sideload with no confirmation, so a build script can drive it. Two things gate it: the sender must hold `android.permission.DUMP`, whose protection level is `signature|privileged|development`, which an adb shell has and an installed app cannot get, and Show debug options must be on. A broadcast arriving with debug options off now says so in a snackbar rather than only in the log.

The receiver's work runs off the main thread behind `goAsync()`, since `onReceive` would otherwise read settings and stat external storage there. Note this does not hold the process for the whole wait-for-watch window, because `sideloadFirmware` is fire and forget. Doing that properly needs the foreground service and is left alone here.

coredevices/PebbleOS#1845 documents both ways of installing a `.pbz`, from a file manager and over adb, in the firmware developer docs.

Written with AI assistance (Claude), and exercised on a Pixel 6 with a Pebble Time 2.

---

Aside: I am currently available for mobile or firmware contracting or full-time work. Contact: adrian@pascu.be.
