### PR TITLE
Ask before installing firmware opened from a file

### DIFF
--- a/composeApp/src/androidMain/kotlin/coredevices/coreapp/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/coredevices/coreapp/MainActivity.kt
@@ -56,8 +56,9 @@ class MainActivity : ComponentActivity() {
                 setTheme(it)
             }
         }
-        // Handle initial intent that launches the app
-        handleIntent(intent)
+        if (savedInstanceState == null) {
+            handleIntent(intent)
+        }
     }
 
     override fun onNewIntent(intent: Intent) {

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/PebbleDeepLinkHandler.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/PebbleDeepLinkHandler.kt
@@ -46,12 +46,18 @@ interface PebbleDeepLinkHandler {
      * (which needs a foreground Activity), then calls [consumeRequestIndexCompanion].
      */
     val requestIndexCompanion: StateFlow<Boolean>
+
+    val pendingFirmwareSideload: StateFlow<PendingFirmwareSideload?>
     fun consumeRequestIndexCompanion()
+    fun confirmPendingFirmwareSideload()
+    fun dismissPendingFirmwareSideload()
     fun handle(uri: Uri?): Boolean
 
     /** Show a navbar tab on the watch home screen (same mechanism as pebble://navbar links). */
     fun navigateToTab(route: NavBarRoute)
 }
+
+data class PendingFirmwareSideload(val file: Path, val fileName: String)
 
 class RealPebbleDeepLinkHandler(
     private val pebbleAccount: PebbleAccount,
@@ -70,6 +76,9 @@ class RealPebbleDeepLinkHandler(
     override val navigateToPebbleDeepLink = _navigateToPebbleDeepLink.asStateFlow()
     private val _requestIndexCompanion = MutableStateFlow(false)
     override val requestIndexCompanion: StateFlow<Boolean> = _requestIndexCompanion.asStateFlow()
+    private val _pendingFirmwareSideload = MutableStateFlow<PendingFirmwareSideload?>(null)
+    override val pendingFirmwareSideload: StateFlow<PendingFirmwareSideload?> =
+        _pendingFirmwareSideload.asStateFlow()
     private var reservedSideloadCount = 0
 
     override fun consumeRequestIndexCompanion() {
@@ -126,7 +135,7 @@ class RealPebbleDeepLinkHandler(
             }
 
             uri.lastPathSegment?.endsWith(".pbl") ?: false -> handleLanguagePack(uri, uri.lastPathSegment!!)
-            uri.lastPathSegment?.endsWith(".pbz") ?: false -> handleFirmware(uri)
+            uri.lastPathSegment?.endsWith(".pbz") ?: false -> handleFirmware(uri, uri.lastPathSegment!!)
             uri.lastPathSegment?.endsWith(".pbw") ?: false -> handleApp(uri)
             uri.scheme == "content" -> handleContentFallback(uri)
             else -> false
@@ -143,7 +152,7 @@ class RealPebbleDeepLinkHandler(
         logger.d { "filename: $name" }
         return when {
             name.endsWith(".pbl") -> handleLanguagePack(uri, name)
-            name.endsWith(".pbz") -> handleFirmware(uri)
+            name.endsWith(".pbz") -> handleFirmware(uri, name)
             name.endsWith(".pbw") -> handleApp(uri)
             else -> false
         }
@@ -169,7 +178,7 @@ class RealPebbleDeepLinkHandler(
         return true
     }
 
-    private fun handleFirmware(uri: Uri): Boolean {
+    private fun handleFirmware(uri: Uri, fileName: String): Boolean {
         logger.v { "handleFirmware() $uri" }
         val file = writeFile(context, uri)
         if (file == null) {
@@ -177,7 +186,12 @@ class RealPebbleDeepLinkHandler(
             _snackBarMessages.tryEmit("Failed to read firmware file")
             return false
         }
-        sideloadFirmware(reserveSideloadCopy(file))
+        val previous = _pendingFirmwareSideload.value
+        val reserved = reserveSideloadCopy(file)
+        _pendingFirmwareSideload.value = PendingFirmwareSideload(reserved, fileName)
+        previous?.takeIf { it.file != reserved }
+            ?.let { SystemFileSystem.delete(it.file, mustExist = false) }
+        navigateToTab(PebbleNavBarRoutes.WatchesRoute)
         return true
     }
 
@@ -205,6 +219,18 @@ class RealPebbleDeepLinkHandler(
         } catch (e: Exception) {
             logger.w(e) { "sweepStaleSideloadCopies failed" }
         }
+    }
+
+    override fun confirmPendingFirmwareSideload() {
+        val pending = _pendingFirmwareSideload.value ?: return
+        _pendingFirmwareSideload.value = null
+        sideloadFirmware(pending.file)
+    }
+
+    override fun dismissPendingFirmwareSideload() {
+        val pending = _pendingFirmwareSideload.value ?: return
+        _pendingFirmwareSideload.value = null
+        SystemFileSystem.delete(pending.file, mustExist = false)
     }
 
     private fun sideloadFirmware(file: Path) {

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/PebbleDeepLinkHandler.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/PebbleDeepLinkHandler.kt
@@ -22,9 +22,13 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.io.files.Path
+import kotlin.time.Duration.Companion.seconds
 
 expect fun readNameFromContentUri(appContext: AppContext, uri: Uri): String?
 
@@ -168,12 +172,32 @@ class RealPebbleDeepLinkHandler(
         val file = writeFile(context, uri)
         if (file == null) {
             logger.w { "handleFirmware: couldn't write file" }
+            _snackBarMessages.tryEmit("Failed to read firmware file")
             return false
         }
-        libPebble.watches.value.filterIsInstance<ConnectedPebble.Firmware>().forEach {
-            it.sideloadFirmware(file)
-        }
+        sideloadFirmware(file)
         return true
+    }
+
+    private fun sideloadFirmware(file: Path) {
+        GlobalScope.launch {
+            val watches = withTimeoutOrNull(CONNECTED_WATCH_TIMEOUT) {
+                libPebble.watches
+                    .map { it.filterIsInstance<ConnectedPebble.Firmware>() }
+                    .first { it.isNotEmpty() }
+            }
+            if (watches == null) {
+                logger.w { "sideloadFirmware: no connected watch after $CONNECTED_WATCH_TIMEOUT" }
+                _snackBarMessages.tryEmit("Failed to sideload firmware: no connected watch")
+                return@launch
+            }
+            logger.i { "sideloadFirmware: sideloading to ${watches.size} watch(es)" }
+            navigateToTab(PebbleNavBarRoutes.WatchesRoute)
+            _snackBarMessages.tryEmit("Sideloading firmware...")
+            watches.forEach {
+                it.sideloadFirmware(file)
+            }
+        }
     }
 
     private fun handleApp(uri: Uri): Boolean {
@@ -274,6 +298,7 @@ class RealPebbleDeepLinkHandler(
     }
 
     companion object {
+        private val CONNECTED_WATCH_TIMEOUT = 60.seconds
         private const val CUSTOM_BOOT_CONFIG_URL: String = "custom-boot-config-url"
         private const val STORE_URL: String = "appstore"
         private const val NAVBAR_URL: String = "navbar"

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/PebbleDeepLinkHandler.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/PebbleDeepLinkHandler.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
 import kotlin.time.Duration.Companion.seconds
 
 expect fun readNameFromContentUri(appContext: AppContext, uri: Uri): String?
@@ -69,6 +70,7 @@ class RealPebbleDeepLinkHandler(
     override val navigateToPebbleDeepLink = _navigateToPebbleDeepLink.asStateFlow()
     private val _requestIndexCompanion = MutableStateFlow(false)
     override val requestIndexCompanion: StateFlow<Boolean> = _requestIndexCompanion.asStateFlow()
+    private var reservedSideloadCount = 0
 
     override fun consumeRequestIndexCompanion() {
         _requestIndexCompanion.value = false
@@ -175,8 +177,34 @@ class RealPebbleDeepLinkHandler(
             _snackBarMessages.tryEmit("Failed to read firmware file")
             return false
         }
-        sideloadFirmware(file)
+        sideloadFirmware(reserveSideloadCopy(file))
         return true
+    }
+
+    private fun reserveSideloadCopy(shared: Path): Path {
+        val directory = shared.parent ?: return shared
+        if (reservedSideloadCount == 0) {
+            sweepStaleSideloadCopies(directory)
+        }
+        val reserved = Path(directory, "$RESERVED_SIDELOAD_PREFIX${reservedSideloadCount++}.pbz")
+        return try {
+            SystemFileSystem.delete(reserved, mustExist = false)
+            SystemFileSystem.atomicMove(shared, reserved)
+            reserved
+        } catch (e: Exception) {
+            logger.w(e) { "reserveSideloadCopy: falling back to the shared path" }
+            shared
+        }
+    }
+
+    private fun sweepStaleSideloadCopies(directory: Path) {
+        try {
+            SystemFileSystem.list(directory)
+                .filter { it.name.startsWith(RESERVED_SIDELOAD_PREFIX) }
+                .forEach { SystemFileSystem.delete(it, mustExist = false) }
+        } catch (e: Exception) {
+            logger.w(e) { "sweepStaleSideloadCopies failed" }
+        }
     }
 
     private fun sideloadFirmware(file: Path) {
@@ -299,6 +327,7 @@ class RealPebbleDeepLinkHandler(
 
     companion object {
         private val CONNECTED_WATCH_TIMEOUT = 60.seconds
+        private const val RESERVED_SIDELOAD_PREFIX = "pending_sideload_"
         private const val CUSTOM_BOOT_CONFIG_URL: String = "custom-boot-config-url"
         private const val STORE_URL: String = "appstore"
         private const val NAVBAR_URL: String = "navbar"

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/PreviewUtil.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/PreviewUtil.kt
@@ -28,6 +28,7 @@ import coredevices.firestore.UsersDao
 import coredevices.libindex.device.IndexIdentifier
 import coredevices.pebble.PebbleDeepLinkHandler
 import coredevices.pebble.PebbleFeatures
+import coredevices.pebble.PendingFirmwareSideload
 import coredevices.pebble.Platform
 import coredevices.pebble.RealPebbleDeepLinkHandler
 import coredevices.pebble.account.BootConfig
@@ -340,7 +341,11 @@ private fun fakePebbleModule(appContext: AppContext) = module {
         override val snackBarMessages: SharedFlow<String> = MutableSharedFlow()
         override val navigateToPebbleDeepLink: StateFlow<RealPebbleDeepLinkHandler.PebbleDeepLink?> = MutableStateFlow(null)
         override val requestIndexCompanion: StateFlow<Boolean> = MutableStateFlow(false)
+        override val pendingFirmwareSideload: StateFlow<PendingFirmwareSideload?> =
+            MutableStateFlow(null)
         override fun consumeRequestIndexCompanion() {}
+        override fun confirmPendingFirmwareSideload() {}
+        override fun dismissPendingFirmwareSideload() {}
         override fun handle(uri: Uri?): Boolean = true
         override fun navigateToTab(route: NavBarRoute) {}
     }

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchHomeScreen.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchHomeScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.material.icons.outlined.Notifications
 import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material.icons.outlined.Tune
 import androidx.compose.material.icons.outlined.Watch
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.Icon
@@ -328,6 +329,29 @@ fun WatchHomeScreen(
             }
         }
         val deepLinkHandler: PebbleDeepLinkHandler = koinInject()
+        val pendingFirmwareSideload by deepLinkHandler.pendingFirmwareSideload.collectAsState()
+        pendingFirmwareSideload?.let { pending ->
+            AlertDialog(
+                onDismissRequest = deepLinkHandler::dismissPendingFirmwareSideload,
+                title = { Text("Sideload firmware?") },
+                text = {
+                    Text(
+                        "Install ${pending.fileName} on every connected watch? Only install " +
+                                "firmware from sources you trust."
+                    )
+                },
+                confirmButton = {
+                    TextButton(onClick = deepLinkHandler::confirmPendingFirmwareSideload) {
+                        Text("Install")
+                    }
+                },
+                dismissButton = {
+                    TextButton(onClick = deepLinkHandler::dismissPendingFirmwareSideload) {
+                        Text("Cancel")
+                    }
+                },
+            )
+        }
         LaunchedEffect(Unit) {
             scope.launch {
                 deepLinkHandler.snackBarMessages.collect { message ->


### PR DESCRIPTION
Firmware opened from a file used to flash every connected watch straight away. It now waits for an explicit Install.

> [!WARNING]
> **The released app installs firmware with no confirmation.** Any `.pbz` handed to `MainActivity` through its exported VIEW filter is flashed to every connected watch immediately, so one tap on a firmware file from a download or a chat puts unsigned firmware on a paired watch, and any other installed app can hand one over while it is in the foreground. Confirmed on the current Play Store build with "Show debug options" off, on a Pebble Time 2.

| Confirmation before installing | Sideload with no watch connected |
| --- | --- |
| ![Dialog asking whether to install the opened firmware file](https://github.com/adipascu/mobileapp/releases/download/pr-assets/sideload-confirm-dialog.png) | ![Snackbar reporting that no watch was connected](https://github.com/adipascu/mobileapp/releases/download/pr-assets/sideload-failure-snackbar.png) |

One commit per section below, in that order. The two changes before the dialog are what make waiting for an answer safe.

## Reporting sideload errors

Sideloading waits up to a minute for a watch to connect and says so while it works. If none turns up it reports `Failed to sideload firmware: no connected watch` in a snackbar, and a firmware file the app cannot read reports that too. Previously both cases were silent.

## Copying the firmware to a private file

An opened firmware file is moved to a file of its own, named `pending_sideload_0.pbz`, then `pending_sideload_1.pbz` for the next one, and the flash reads that. Opening a second firmware file therefore cannot change the bytes of one that is already flashing, which matters because a flash reads from disk repeatedly for the minutes a transfer lasts. Files left behind by flashes that never ran are deleted the first time the app opens one after starting.

## Confirmation before installing

Firmware arriving through a VIEW intent waits for an explicit Install, naming the file it is about to flash. Cancel deletes the copy, as does replacing one pending file with another. Install starts the flash and switches to the Devices tab, where the watch card already draws an update progress bar, since sideloads drive the same `firmwareUpdateState` machine as an official update.

A dialog rather than a setting, because this path has to keep working for someone who downloads a `.pbz` and taps it.

## Handling the launch intent only on a fresh start

The launch intent is acted on only when the activity starts fresh. Multitasking away and resuming the app no longer replays the deep link and asks again to install firmware that is already installed.

coredevices/mobileapp#321 builds on this to make the same sideload scriptable over adb.

Written with AI assistance (Claude), and exercised on a Pixel 6 with a Pebble Time 2.

---

Aside: I am currently available for mobile or firmware contracting or full-time work. Contact: adrian@pascu.be.
