### PR TITLE
Index: let a click action call the configured webhook

### DIFF
--- a/experimental/schemas/coredevices.ring.database.room.RingDatabase/33.json
+++ b/experimental/schemas/coredevices.ring.database.room.RingDatabase/33.json
@@ -1,0 +1,1319 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 33,
+    "identityHash": "6576054b5f2741a416441285f88efec4",
+    "entities": [
+      {
+        "tableName": "LocalReminderData",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `time` INTEGER, `message` TEXT NOT NULL, `recordingId` TEXT DEFAULT NULL, `notifyBeforeMillis` INTEGER DEFAULT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "time",
+            "columnName": "time",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "message",
+            "columnName": "message",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recordingId",
+            "columnName": "recordingId",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "notifyBeforeMillis",
+            "columnName": "notifyBeforeMillis",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "CachedRecordingMetadata",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sampleRate` INTEGER NOT NULL, `mimeType` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sampleRate",
+            "columnName": "sampleRate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mimeType",
+            "columnName": "mimeType",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "RingDebugTransfer",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `satelliteName` TEXT, `satelliteId` TEXT NOT NULL, `satelliteFirmwareVersion` TEXT NOT NULL, `satelliteLastAdvertisementTimestamp` INTEGER NOT NULL, `collectionIndex` INTEGER NOT NULL, `collectionStartCount` INTEGER NOT NULL DEFAULT -1, `buttonSequence` TEXT, `sampleCount` INTEGER NOT NULL, `sampleRate` INTEGER NOT NULL, `buttonReleaseTimestamp` INTEGER, `transferCompleteTimestamp` INTEGER NOT NULL, `storedPath` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "satelliteName",
+            "columnName": "satelliteName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "satelliteId",
+            "columnName": "satelliteId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "satelliteFirmwareVersion",
+            "columnName": "satelliteFirmwareVersion",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "satelliteLastAdvertisementTimestamp",
+            "columnName": "satelliteLastAdvertisementTimestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "collectionIndex",
+            "columnName": "collectionIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "collectionStartCount",
+            "columnName": "collectionStartCount",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "-1"
+          },
+          {
+            "fieldPath": "buttonSequence",
+            "columnName": "buttonSequence",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sampleCount",
+            "columnName": "sampleCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sampleRate",
+            "columnName": "sampleRate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "buttonReleaseTimestamp",
+            "columnName": "buttonReleaseTimestamp",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "transferCompleteTimestamp",
+            "columnName": "transferCompleteTimestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storedPath",
+            "columnName": "storedPath",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "LocalRecording",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `localTimestamp` INTEGER NOT NULL, `firestoreId` TEXT, `updated` INTEGER NOT NULL DEFAULT 0, `assistantTitle` TEXT, `lastPushedUpdated` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localTimestamp",
+            "columnName": "localTimestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firestoreId",
+            "columnName": "firestoreId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "updated",
+            "columnName": "updated",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "assistantTitle",
+            "columnName": "assistantTitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastPushedUpdated",
+            "columnName": "lastPushedUpdated",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LocalRecording_firestoreId",
+            "unique": true,
+            "columnNames": [
+              "firestoreId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_LocalRecording_firestoreId` ON `${TABLE_NAME}` (`firestoreId`)"
+          },
+          {
+            "name": "index_LocalRecording_localTimestamp",
+            "unique": false,
+            "columnNames": [
+              "localTimestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LocalRecording_localTimestamp` ON `${TABLE_NAME}` (`localTimestamp`)"
+          }
+        ]
+      },
+      {
+        "tableName": "ConversationMessageEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `recordingId` INTEGER NOT NULL, `timestamp` INTEGER NOT NULL, `role` TEXT NOT NULL, `content` TEXT, `tool_calls` TEXT, `tool_call_id` TEXT, `semantic_result` TEXT, `language_model_used` TEXT, `is_forced_tool` INTEGER NOT NULL DEFAULT 0, FOREIGN KEY(`recordingId`) REFERENCES `LocalRecording`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recordingId",
+            "columnName": "recordingId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "document.role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "document.content",
+            "columnName": "content",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "document.tool_calls",
+            "columnName": "tool_calls",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "document.tool_call_id",
+            "columnName": "tool_call_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "document.semantic_result",
+            "columnName": "semantic_result",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "document.language_model_used",
+            "columnName": "language_model_used",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "document.is_forced_tool",
+            "columnName": "is_forced_tool",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_ConversationMessageEntity_recordingId",
+            "unique": false,
+            "columnNames": [
+              "recordingId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_ConversationMessageEntity_recordingId` ON `${TABLE_NAME}` (`recordingId`)"
+          },
+          {
+            "name": "index_ConversationMessageEntity_recordingId_role_timestamp",
+            "unique": false,
+            "columnNames": [
+              "recordingId",
+              "role",
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_ConversationMessageEntity_recordingId_role_timestamp` ON `${TABLE_NAME}` (`recordingId`, `role`, `timestamp`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "LocalRecording",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "recordingId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "RecordingEntryEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `recordingId` INTEGER NOT NULL, `timestamp` INTEGER NOT NULL, `fileName` TEXT, `status` TEXT NOT NULL, `transcription` TEXT, `transcribedUsingModel` TEXT DEFAULT NULL, `error` TEXT, `ringTransferInfo` TEXT, `userMessageId` INTEGER, FOREIGN KEY(`recordingId`) REFERENCES `LocalRecording`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recordingId",
+            "columnName": "recordingId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileName",
+            "columnName": "fileName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transcription",
+            "columnName": "transcription",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "transcribedUsingModel",
+            "columnName": "transcribedUsingModel",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "error",
+            "columnName": "error",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ringTransferInfo",
+            "columnName": "ringTransferInfo",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userMessageId",
+            "columnName": "userMessageId",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_RecordingEntryEntity_userMessageId",
+            "unique": false,
+            "columnNames": [
+              "userMessageId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_RecordingEntryEntity_userMessageId` ON `${TABLE_NAME}` (`userMessageId`)"
+          },
+          {
+            "name": "index_RecordingEntryEntity_recordingId",
+            "unique": false,
+            "columnNames": [
+              "recordingId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_RecordingEntryEntity_recordingId` ON `${TABLE_NAME}` (`recordingId`)"
+          },
+          {
+            "name": "index_RecordingEntryEntity_recordingId_timestamp",
+            "unique": false,
+            "columnNames": [
+              "recordingId",
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_RecordingEntryEntity_recordingId_timestamp` ON `${TABLE_NAME}` (`recordingId`, `timestamp`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "LocalRecording",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "recordingId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "RingTransfer",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `recordingId` INTEGER, `recordingEntryId` INTEGER, `isCurrentIndexIteration` INTEGER NOT NULL, `status` TEXT NOT NULL, `fileId` TEXT, `createdAt` INTEGER NOT NULL, `transferInfo_collectionStartIndex` INTEGER, `transferInfo_collectionEndIndex` INTEGER, `transferInfo_buttonPressed` INTEGER, `transferInfo_buttonReleased` INTEGER, `transferInfo_advertisementReceived` INTEGER, `transferInfo_transferCompleted` INTEGER, `transferInfo_buttonReleaseAdvertisementLatencyMs` INTEGER, FOREIGN KEY(`recordingId`) REFERENCES `LocalRecording`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`recordingEntryId`) REFERENCES `RecordingEntryEntity`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recordingId",
+            "columnName": "recordingId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "recordingEntryId",
+            "columnName": "recordingEntryId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isCurrentIndexIteration",
+            "columnName": "isCurrentIndexIteration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileId",
+            "columnName": "fileId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transferInfo.collectionStartIndex",
+            "columnName": "transferInfo_collectionStartIndex",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "transferInfo.collectionEndIndex",
+            "columnName": "transferInfo_collectionEndIndex",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "transferInfo.buttonPressed",
+            "columnName": "transferInfo_buttonPressed",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "transferInfo.buttonReleased",
+            "columnName": "transferInfo_buttonReleased",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "transferInfo.advertisementReceived",
+            "columnName": "transferInfo_advertisementReceived",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "transferInfo.transferCompleted",
+            "columnName": "transferInfo_transferCompleted",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "transferInfo.buttonReleaseAdvertisementLatencyMs",
+            "columnName": "transferInfo_buttonReleaseAdvertisementLatencyMs",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_RingTransfer_recordingId",
+            "unique": false,
+            "columnNames": [
+              "recordingId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_RingTransfer_recordingId` ON `${TABLE_NAME}` (`recordingId`)"
+          },
+          {
+            "name": "index_RingTransfer_recordingEntryId",
+            "unique": false,
+            "columnNames": [
+              "recordingEntryId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_RingTransfer_recordingEntryId` ON `${TABLE_NAME}` (`recordingEntryId`)"
+          },
+          {
+            "name": "index_RingTransfer_isCurrentIndexIteration_transferInfo_collectionStartIndex",
+            "unique": false,
+            "columnNames": [
+              "isCurrentIndexIteration",
+              "transferInfo_collectionStartIndex"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_RingTransfer_isCurrentIndexIteration_transferInfo_collectionStartIndex` ON `${TABLE_NAME}` (`isCurrentIndexIteration`, `transferInfo_collectionStartIndex`)"
+          },
+          {
+            "name": "index_RingTransfer_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_RingTransfer_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "LocalRecording",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "recordingId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "RecordingEntryEntity",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "recordingEntryId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "BuiltinMcpGroupAssociation",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`groupId` INTEGER NOT NULL, `builtinMcpName` TEXT NOT NULL, PRIMARY KEY(`groupId`, `builtinMcpName`), FOREIGN KEY(`groupId`) REFERENCES `McpSandboxGroupEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "groupId",
+            "columnName": "groupId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "builtinMcpName",
+            "columnName": "builtinMcpName",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "groupId",
+            "builtinMcpName"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_BuiltinMcpGroupAssociation_groupId",
+            "unique": false,
+            "columnNames": [
+              "groupId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_BuiltinMcpGroupAssociation_groupId` ON `${TABLE_NAME}` (`groupId`)"
+          },
+          {
+            "name": "index_BuiltinMcpGroupAssociation_groupId_builtinMcpName",
+            "unique": true,
+            "columnNames": [
+              "groupId",
+              "builtinMcpName"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_BuiltinMcpGroupAssociation_groupId_builtinMcpName` ON `${TABLE_NAME}` (`groupId`, `builtinMcpName`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "McpSandboxGroupEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "groupId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "HttpMcpGroupAssociation",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`groupId` INTEGER NOT NULL, `httpMcpId` INTEGER NOT NULL, PRIMARY KEY(`groupId`, `httpMcpId`), FOREIGN KEY(`groupId`) REFERENCES `McpSandboxGroupEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`httpMcpId`) REFERENCES `HttpMcpServerEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "groupId",
+            "columnName": "groupId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "httpMcpId",
+            "columnName": "httpMcpId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "groupId",
+            "httpMcpId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_HttpMcpGroupAssociation_groupId",
+            "unique": false,
+            "columnNames": [
+              "groupId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_HttpMcpGroupAssociation_groupId` ON `${TABLE_NAME}` (`groupId`)"
+          },
+          {
+            "name": "index_HttpMcpGroupAssociation_httpMcpId",
+            "unique": false,
+            "columnNames": [
+              "httpMcpId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_HttpMcpGroupAssociation_httpMcpId` ON `${TABLE_NAME}` (`httpMcpId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "McpSandboxGroupEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "groupId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "HttpMcpServerEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "httpMcpId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "HttpMcpServerEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `cachedTitle` TEXT NOT NULL, `name` TEXT NOT NULL, `url` TEXT NOT NULL, `streamable` INTEGER NOT NULL, `authHeader` TEXT, `includedPrompts` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedTitle",
+            "columnName": "cachedTitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "streamable",
+            "columnName": "streamable",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "authHeader",
+            "columnName": "authHeader",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "includedPrompts",
+            "columnName": "includedPrompts",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "McpSandboxGroupEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `title` TEXT NOT NULL, `modelType` TEXT NOT NULL DEFAULT 'IndexAgent')",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelType",
+            "columnName": "modelType",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'IndexAgent'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "RecordingProcessingTaskEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `created` INTEGER NOT NULL, `lastAttempt` INTEGER, `attempts` INTEGER NOT NULL, `status` TEXT NOT NULL, `recordingId` INTEGER, `type` TEXT NOT NULL, `buttonSequence` TEXT, `lastSuccessfulStage` TEXT, `transferId` INTEGER, `fileId` TEXT, `transcription` TEXT, FOREIGN KEY(`transferId`) REFERENCES `RingTransfer`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL , FOREIGN KEY(`recordingId`) REFERENCES `LocalRecording`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "created",
+            "columnName": "created",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAttempt",
+            "columnName": "lastAttempt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "attempts",
+            "columnName": "attempts",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recordingId",
+            "columnName": "recordingId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "buttonSequence",
+            "columnName": "buttonSequence",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastSuccessfulStage",
+            "columnName": "lastSuccessfulStage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "transferId",
+            "columnName": "transferId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "fileId",
+            "columnName": "fileId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "transcription",
+            "columnName": "transcription",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_RecordingProcessingTaskEntity_lastAttempt",
+            "unique": false,
+            "columnNames": [
+              "lastAttempt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_RecordingProcessingTaskEntity_lastAttempt` ON `${TABLE_NAME}` (`lastAttempt`)"
+          },
+          {
+            "name": "index_RecordingProcessingTaskEntity_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_RecordingProcessingTaskEntity_status` ON `${TABLE_NAME}` (`status`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "RingTransfer",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "transferId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "LocalRecording",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "recordingId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "TraceSessionEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `started` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "started",
+            "columnName": "started",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "TraceEntryEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sessionId` INTEGER NOT NULL, `timeMark` INTEGER NOT NULL, `type` TEXT NOT NULL, `data` TEXT, `recordingId` INTEGER DEFAULT NULL, `transferId` INTEGER DEFAULT NULL, FOREIGN KEY(`sessionId`) REFERENCES `TraceSessionEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timeMark",
+            "columnName": "timeMark",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "data",
+            "columnName": "data",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "recordingId",
+            "columnName": "recordingId",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "transferId",
+            "columnName": "transferId",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_TraceEntryEntity_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_TraceEntryEntity_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          },
+          {
+            "name": "index_TraceEntryEntity_recordingId",
+            "unique": false,
+            "columnNames": [
+              "recordingId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_TraceEntryEntity_recordingId` ON `${TABLE_NAME}` (`recordingId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "TraceSessionEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sessionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "CachedItem",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`firestoreId` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `title` TEXT NOT NULL, `body` TEXT NOT NULL, `done` INTEGER NOT NULL DEFAULT 0, `dueAt` INTEGER, `parentListIdsCsv` TEXT NOT NULL DEFAULT '', `sourceRecordingId` TEXT, `sourceToolCallId` TEXT, `metadata` TEXT NOT NULL DEFAULT '{\"type\":\"note\"}', `deleted` INTEGER NOT NULL DEFAULT 0, `locked` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`firestoreId`))",
+        "fields": [
+          {
+            "fieldPath": "firestoreId",
+            "columnName": "firestoreId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "body",
+            "columnName": "body",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "done",
+            "columnName": "done",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "dueAt",
+            "columnName": "dueAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "parentListIdsCsv",
+            "columnName": "parentListIdsCsv",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "sourceRecordingId",
+            "columnName": "sourceRecordingId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceToolCallId",
+            "columnName": "sourceToolCallId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "metadata",
+            "columnName": "metadata",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'{\"type\":\"note\"}'"
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "locked",
+            "columnName": "locked",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "firestoreId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_CachedItem_firestoreId",
+            "unique": true,
+            "columnNames": [
+              "firestoreId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_CachedItem_firestoreId` ON `${TABLE_NAME}` (`firestoreId`)"
+          },
+          {
+            "name": "index_CachedItem_sourceRecordingId",
+            "unique": false,
+            "columnNames": [
+              "sourceRecordingId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_CachedItem_sourceRecordingId` ON `${TABLE_NAME}` (`sourceRecordingId`)"
+          },
+          {
+            "name": "index_CachedItem_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_CachedItem_updatedAt` ON `${TABLE_NAME}` (`updatedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "CachedList",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`firestoreId` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `title` TEXT NOT NULL, `icon` TEXT NOT NULL DEFAULT '📝', `listKind` TEXT NOT NULL DEFAULT 'note', `seed` TEXT, `deleted` INTEGER NOT NULL DEFAULT 0, `locked` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`firestoreId`))",
+        "fields": [
+          {
+            "fieldPath": "firestoreId",
+            "columnName": "firestoreId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'📝'"
+          },
+          {
+            "fieldPath": "listKind",
+            "columnName": "listKind",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'note'"
+          },
+          {
+            "fieldPath": "seed",
+            "columnName": "seed",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "locked",
+            "columnName": "locked",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "firestoreId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_CachedList_firestoreId",
+            "unique": true,
+            "columnNames": [
+              "firestoreId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_CachedList_firestoreId` ON `${TABLE_NAME}` (`firestoreId`)"
+          },
+          {
+            "name": "index_CachedList_seed",
+            "unique": false,
+            "columnNames": [
+              "seed"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_CachedList_seed` ON `${TABLE_NAME}` (`seed`)"
+          },
+          {
+            "name": "index_CachedList_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_CachedList_updatedAt` ON `${TABLE_NAME}` (`updatedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "ClickActionBinding",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `clickCount` INTEGER NOT NULL, `action` TEXT NOT NULL, `enabled` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "clickCount",
+            "columnName": "clickCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "action",
+            "columnName": "action",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_ClickActionBinding_clickCount",
+            "unique": true,
+            "columnNames": [
+              "clickCount"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_ClickActionBinding_clickCount` ON `${TABLE_NAME}` (`clickCount`)"
+          }
+        ]
+      }
+    ],
+    "views": [
+      {
+        "viewName": "RecordingFeedItem",
+        "createSql": "CREATE VIEW `${VIEW_NAME}` AS SELECT \n        lr.id AS rootRecordingId, \n        lr.localTimestamp,\n        re.*, \n        cm.semantic_result\n    FROM LocalRecording AS lr\n    LEFT JOIN RecordingEntryEntity AS re ON re.id = (\n        SELECT id \n        FROM RecordingEntryEntity \n        WHERE recordingId = lr.id \n        ORDER BY timestamp DESC\n        LIMIT 1\n    )\n    LEFT JOIN ConversationMessageEntity AS cm ON cm.id = (\n        SELECT id \n        FROM ConversationMessageEntity \n        WHERE recordingId = lr.id \n        AND role = 'tool' \n        ORDER BY timestamp DESC \n        LIMIT 1\n    )"
+      },
+      {
+        "viewName": "RingTransferFeedItem",
+        "createSql": "CREATE VIEW `${VIEW_NAME}` AS SELECT\n            RT.id AS transfer_id,\n            RT.recordingId AS transfer_recordingId,\n            RT.recordingEntryId AS transfer_recordingEntryId,\n            RT.isCurrentIndexIteration AS transfer_isCurrentIndexIteration,\n            RT.status AS transfer_status,\n            RT.fileId AS transfer_fileId,\n            RT.createdAt AS transfer_createdAt,\n            RT.transferInfo_collectionStartIndex AS transfer_transferInfo_collectionStartIndex,\n            RT.transferInfo_collectionEndIndex AS transfer_transferInfo_collectionEndIndex,\n            RT.transferInfo_buttonPressed AS transfer_transferInfo_buttonPressed,\n            RT.transferInfo_buttonReleased AS transfer_transferInfo_buttonReleased,\n            RT.transferInfo_advertisementReceived AS transfer_transferInfo_advertisementReceived,\n            RT.transferInfo_transferCompleted AS transfer_transferInfo_transferCompleted,\n            RT.transferInfo_buttonReleaseAdvertisementLatencyMs AS transfer_transferInfo_buttonReleaseAdvertisementLatencyMs,\n\n            RF.rootRecordingId AS feedItem_rootRecordingId,\n            RF.localTimestamp AS feedItem_localTimestamp,\n            RF.semantic_result AS feedItem_semantic_result,\n            RF.id AS feedItem_id,\n            RF.recordingId AS feedItem_recordingId,\n            RF.timestamp AS feedItem_timestamp,\n            RF.fileName AS feedItem_fileName,\n            RF.status AS feedItem_status,\n            RF.transcription AS feedItem_transcription,\n            RF.error AS feedItem_error,\n            RF.ringTransferInfo AS feedItem_ringTransferInfo,\n            RF.userMessageId AS feedItem_userMessageId\n\n        FROM RingTransfer AS RT\n        LEFT JOIN RecordingFeedItem AS RF ON RT.recordingId = RF.rootRecordingId\n        UNION ALL\n        SELECT \n            RT.id AS transfer_id,\n            RT.recordingId AS transfer_recordingId,\n            RT.recordingEntryId AS transfer_recordingEntryId,\n            RT.isCurrentIndexIteration AS transfer_isCurrentIndexIteration,\n            RT.status AS transfer_status,\n            RT.fileId AS transfer_fileId,\n            RT.createdAt AS transfer_createdAt,\n            RT.transferInfo_collectionStartIndex AS transfer_transferInfo_collectionStartIndex,\n            RT.transferInfo_collectionEndIndex AS transfer_transferInfo_collectionEndIndex,\n            RT.transferInfo_buttonPressed AS transfer_transferInfo_buttonPressed,\n            RT.transferInfo_buttonReleased AS transfer_transferInfo_buttonReleased,\n            RT.transferInfo_advertisementReceived AS transfer_transferInfo_advertisementReceived,\n            RT.transferInfo_transferCompleted AS transfer_transferInfo_transferCompleted,\n            RT.transferInfo_buttonReleaseAdvertisementLatencyMs AS transfer_transferInfo_buttonReleaseAdvertisementLatencyMs,\n\n            RF.rootRecordingId AS feedItem_rootRecordingId,\n            RF.localTimestamp AS feedItem_localTimestamp,\n            RF.semantic_result AS feedItem_semantic_result,\n            RF.id AS feedItem_id,\n            RF.recordingId AS feedItem_recordingId,\n            RF.timestamp AS feedItem_timestamp,\n            RF.fileName AS feedItem_fileName,\n            RF.status AS feedItem_status,\n            RF.transcription AS feedItem_transcription,\n            RF.error AS feedItem_error,\n            RF.ringTransferInfo AS feedItem_ringTransferInfo,\n            RF.userMessageId AS feedItem_userMessageId\n            \n        FROM RecordingFeedItem AS RF\n        LEFT JOIN RingTransfer AS RT ON RF.rootRecordingId = RT.recordingId\n        WHERE RT.id IS NULL"
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '6576054b5f2741a416441285f88efec4')"
+    ]
+  }
+}

--- a/experimental/src/commonMain/kotlin/coredevices/experimentalModule.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/experimentalModule.kt
@@ -59,6 +59,7 @@ import coredevices.ring.firestoreModule
 import coredevices.ring.mcpModule
 import coredevices.ring.service.FirestoreRingDebugDelegate
 import coredevices.ring.service.ClickActionExecutor
+import coredevices.ring.service.ClickActionToolCatalog
 import coredevices.ring.service.IndexButtonActionHandler
 import coredevices.ring.service.IndexButtonSequenceRecorder
 import coredevices.ring.service.IndexNotificationManager
@@ -240,6 +241,7 @@ val experimentalModule = module {
     singleOf(::RecordingProcessor)
     singleOf(::ClickActionRepository)
     singleOf(::ClickActionExecutor)
+    singleOf(::ClickActionToolCatalog)
     singleOf(::IndexButtonActionHandler)
     singleOf(::IndexButtonSequenceRecorder)
     singleOf(::FirestoreRingDebugDelegate) bind KMPHaversineDebugDelegate::class

--- a/experimental/src/commonMain/kotlin/coredevices/experimentalModule.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/experimentalModule.kt
@@ -39,6 +39,7 @@ import coredevices.ring.audio.M4aEncoder
 import coredevices.ring.database.Preferences
 import coredevices.ring.database.PreferencesImpl
 import coredevices.ring.database.room.RingDatabase
+import coredevices.ring.database.room.repository.ClickActionRepository
 import coredevices.ring.database.room.repository.McpSandboxRepository
 import coredevices.ring.database.room.repository.RecordingProcessingTaskRepository
 import coredevices.ring.database.room.repository.ItemRepository
@@ -57,6 +58,7 @@ import coredevices.ring.agent.integrations.obsidian.ObsidianPreferences
 import coredevices.ring.firestoreModule
 import coredevices.ring.mcpModule
 import coredevices.ring.service.FirestoreRingDebugDelegate
+import coredevices.ring.service.ClickActionExecutor
 import coredevices.ring.service.IndexButtonActionHandler
 import coredevices.ring.service.IndexButtonSequenceRecorder
 import coredevices.ring.service.IndexNotificationManager
@@ -159,6 +161,9 @@ val experimentalModule = module {
     single {
         get<RingDatabase>().cachedListDao()
     }
+    single {
+        get<RingDatabase>().clickActionBindingDao()
+    }
     singleOf(::RecordingRepository)
     single {
         RingTransferRepository(get(), get<RingDatabase>())
@@ -233,6 +238,8 @@ val experimentalModule = module {
     factory { p -> IndexAgentCactus(get<CactusModelProvider>(), p.getOrNull() ?: emptyList(), getOrNull<InferenceBoostProvider>() ?: NoOpInferenceBoostProvider()) }
     singleOf(::AgentFactory)
     singleOf(::RecordingProcessor)
+    singleOf(::ClickActionRepository)
+    singleOf(::ClickActionExecutor)
     singleOf(::IndexButtonActionHandler)
     singleOf(::IndexButtonSequenceRecorder)
     singleOf(::FirestoreRingDebugDelegate) bind KMPHaversineDebugDelegate::class

--- a/experimental/src/commonMain/kotlin/coredevices/ring/agent/McpSessionFactory.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/agent/McpSessionFactory.kt
@@ -36,19 +36,42 @@ class McpSessionFactory(
 
     suspend fun createForSandboxGroup(groupId: Long, scope: CoroutineScope): McpSession {
         val group = mcpSandboxRepository.getGroupById(groupId) ?: throw IllegalArgumentException("MCP Sandbox group with id $groupId not found")
-        if (group.modelType == SandboxModelType.IndexAgent) {
-            return createForNeedleAgent(scope)
+        return if (group.modelType == SandboxModelType.IndexAgent) {
+            createForNeedleAgent(scope)
         } else {
-            val integrations =
-                mcpSandboxRepository.getMcpServerEntriesForGroup(groupId).first().mapNotNull {
-                    when (it) {
-                        is McpServerEntry.BuiltinMcpEntry -> builtinServletRepository.resolveName(it.builtinMcpName)
-                        is McpServerEntry.HttpServerEntry -> it.server.toMcpIntegration()
-                    }
-                }
-            return McpSession(integrations, scope)
+            McpSession(groupIntegrations(groupId), scope)
         }
     }
+
+    /**
+     * Session for invoking a tool the caller has already named, with no model in the loop.
+     *
+     * Deliberately ignores the group's model type: the Needle restriction exists because that
+     * model can only emit tool names it was trained on, which says nothing about what can be
+     * dispatched directly. Gating this on it would hide HTTP MCP servers from callers that
+     * never ask a model to choose.
+     *
+     * [onlyIntegration] narrows the session to a single integration. Opening a session connects
+     * every integration in it, so a caller that already knows which one it needs should say so
+     * rather than pay a network round trip per unrelated HTTP server.
+     */
+    suspend fun createForDirectToolCall(
+        groupId: Long,
+        scope: CoroutineScope,
+        onlyIntegration: String? = null,
+    ): McpSession {
+        val integrations = groupIntegrations(groupId)
+            .filter { onlyIntegration == null || it.name == onlyIntegration }
+        return McpSession(integrations, scope)
+    }
+
+    private suspend fun groupIntegrations(groupId: Long) =
+        mcpSandboxRepository.getMcpServerEntriesForGroup(groupId).first().mapNotNull {
+            when (it) {
+                is McpServerEntry.BuiltinMcpEntry -> builtinServletRepository.resolveName(it.builtinMcpName)
+                is McpServerEntry.HttpServerEntry -> it.server.toMcpIntegration()
+            }
+        }
 }
 
 private fun HttpMcpServerEntity.toMcpIntegration(): HttpMcpIntegration {

--- a/experimental/src/commonMain/kotlin/coredevices/ring/data/entity/room/ClickActionBinding.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/data/entity/room/ClickActionBinding.kt
@@ -56,6 +56,11 @@ sealed interface ClickAction {
         val arguments: JsonObject = JsonObject(emptyMap()),
     ) : ClickAction
 
+    /** Pings the configured Index webhook. Carries no audio or transcript. */
+    @Serializable
+    @SerialName("webhook")
+    data object Webhook : ClickAction
+
     /**
      * A stored action this build can't decode — typically written by a newer version, or by a
      * variant that has since been renamed. Kept as a value rather than failing the read so one

--- a/experimental/src/commonMain/kotlin/coredevices/ring/data/entity/room/ClickActionBinding.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/data/entity/room/ClickActionBinding.kt
@@ -1,0 +1,53 @@
+package coredevices.ring.data.entity.room
+
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * A user-configured binding from a run of short clicks on the ring to an action.
+ *
+ * Click-only sequences reach the app on a non-audio collection, so these actions have no
+ * spoken input to work from — every action carries its own fixed configuration.
+ */
+@Entity(indices = [Index(value = ["clickCount"], unique = true)])
+data class ClickActionBinding(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val clickCount: Int,
+    val action: ClickAction,
+    val enabled: Boolean = true,
+) {
+    companion object {
+        const val MIN_CLICK_COUNT = 1
+
+        /**
+         * Runs longer than this are impractical: each press has to land inside
+         * [coredevices.ring.service.IndexButtonSequenceRecorder.EVENT_DEBOUNCE_MS] of the last.
+         */
+        const val MAX_CLICK_COUNT = 8
+        val CLICK_COUNT_RANGE = MIN_CLICK_COUNT..MAX_CLICK_COUNT
+    }
+}
+
+@Serializable
+sealed interface ClickAction {
+    /**
+     * Runs [text] through the normal agent pipeline via
+     * [coredevices.ring.service.recordings.RecordingProcessingQueue.queueTextProcessing].
+     * Text ending in '?' is routed to the search agent.
+     */
+    @Serializable
+    @SerialName("agent_text")
+    data class AgentText(val text: String) : ClickAction
+
+    /**
+     * A stored action this build can't decode — typically written by a newer version, or by a
+     * variant that has since been renamed. Kept as a value rather than failing the read so one
+     * bad row can't break every query against the table; the binding is inert until re-created.
+     */
+    @Serializable
+    @SerialName("unsupported")
+    data object Unsupported : ClickAction
+}

--- a/experimental/src/commonMain/kotlin/coredevices/ring/data/entity/room/ClickActionBinding.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/data/entity/room/ClickActionBinding.kt
@@ -5,6 +5,7 @@ import androidx.room.Index
 import androidx.room.PrimaryKey
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonObject
 
 /**
  * A user-configured binding from a run of short clicks on the ring to an action.
@@ -41,6 +42,19 @@ sealed interface ClickAction {
     @Serializable
     @SerialName("agent_text")
     data class AgentText(val text: String) : ClickAction
+
+    /**
+     * Calls a single MCP tool directly with fixed [arguments]. No model is involved, so the
+     * outcome is deterministic. Covers both built-in servlets and HTTP MCP servers — they are
+     * the same dispatch path.
+     */
+    @Serializable
+    @SerialName("tool_call")
+    data class ToolCall(
+        val integrationName: String,
+        val toolName: String,
+        val arguments: JsonObject = JsonObject(emptyMap()),
+    ) : ClickAction
 
     /**
      * A stored action this build can't decode — typically written by a newer version, or by a

--- a/experimental/src/commonMain/kotlin/coredevices/ring/database/Preferences.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/database/Preferences.kt
@@ -328,6 +328,18 @@ enum class MusicControlMode(val id: Int) {
     }
 }
 
+/**
+ * Click counts media control already consumes in this mode. A custom click binding on one of
+ * these can never fire, so the dispatcher skips them and the settings UI blocks them.
+ * Must stay in step with the action map in
+ * [coredevices.ring.service.IndexButtonActionHandler].
+ */
+fun MusicControlMode.reservedClickCounts(): Set<Int> = when (this) {
+    MusicControlMode.Disabled -> emptySet()
+    MusicControlMode.SingleClick -> setOf(1, 2)
+    MusicControlMode.DoubleClick -> setOf(2, 3)
+}
+
 enum class SecondaryMode(val id: Int) {
     Disabled(0),
     Search(1),

--- a/experimental/src/commonMain/kotlin/coredevices/ring/database/room/RingDatabase.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/database/room/RingDatabase.kt
@@ -34,6 +34,8 @@ import coredevices.indexai.database.dao.RecordingFeedItem
 import coredevices.indexai.util.JsonSnake
 import coredevices.mcp.data.SemanticResult
 import coredevices.ring.data.entity.room.CachedRecordingMetadata
+import coredevices.ring.data.entity.room.ClickAction
+import coredevices.ring.data.entity.room.ClickActionBinding
 import coredevices.ring.data.entity.room.RecordingProcessingTaskEntity
 import coredevices.ring.data.entity.room.RingDebugTransfer
 import coredevices.ring.data.entity.room.indexfeed.CachedItem
@@ -45,6 +47,7 @@ import coredevices.ring.data.entity.room.reminders.LocalReminderData
 import coredevices.ring.database.room.dao.CachedItemDao
 import coredevices.ring.database.room.dao.CachedListDao
 import coredevices.ring.database.room.dao.CachedRecordingMetadataDao
+import coredevices.ring.database.room.dao.ClickActionBindingDao
 import coredevices.ring.database.room.dao.LocalReminderDao
 import coredevices.ring.database.room.dao.RecordingProcessingTaskDao
 import coredevices.ring.database.room.dao.RingDebugTransferDao
@@ -79,12 +82,13 @@ import kotlin.uuid.Uuid
         TraceEntryEntity::class,
         CachedItem::class,
         CachedList::class,
+        ClickActionBinding::class,
     ],
     views = [
         RecordingFeedItem::class,
         RingTransferFeedItem::class
     ],
-    version = 32,
+    version = 33,
     autoMigrations = [
         AutoMigration(from = 1, to = 2),
         AutoMigration(from = 2, to = 3),
@@ -119,6 +123,8 @@ import kotlin.uuid.Uuid
         AutoMigration(from = 30, to = 31),
         // 31→32: adds LocalReminderData.notifyBeforeMillis (early heads-up notification lead time).
         AutoMigration(from = 31, to = 32),
+        // 32→33: adds ClickActionBinding (custom short-click gesture bindings).
+        AutoMigration(from = 32, to = 33),
     ]
 )
 @TypeConverters(Converters::class)
@@ -140,6 +146,7 @@ abstract class RingDatabase: RoomDatabase() {
     abstract fun traceEntryDao(): TraceEntryDao
     abstract fun cachedItemDao(): CachedItemDao
     abstract fun cachedListDao(): CachedListDao
+    abstract fun clickActionBindingDao(): ClickActionBindingDao
 }
 
 @DeleteColumn("LocalReminderData", "platformId")
@@ -259,6 +266,20 @@ class Converters {
     @TypeConverter
     fun StringToStringList(string: String?) = string?.let {
         JsonSnake.decodeFromString<List<String>>(it)
+    }
+
+    @TypeConverter
+    fun ClickActionToString(action: ClickAction?): String? =
+        action?.let { JsonSnake.encodeToString<ClickAction>(it) }
+
+    @TypeConverter
+    fun StringToClickAction(string: String?): ClickAction? = string?.let {
+        try {
+            JsonSnake.decodeFromString<ClickAction>(it)
+        } catch (e: SerializationException) {
+            Logger.w(e) { "Failed to deserialize ClickAction, marking unsupported: $string" }
+            ClickAction.Unsupported
+        }
     }
 
     @TypeConverter

--- a/experimental/src/commonMain/kotlin/coredevices/ring/database/room/dao/ClickActionBindingDao.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/database/room/dao/ClickActionBindingDao.kt
@@ -1,0 +1,29 @@
+package coredevices.ring.database.room.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import androidx.room.Update
+import coredevices.ring.data.entity.room.ClickActionBinding
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface ClickActionBindingDao {
+    @Query("SELECT * FROM ClickActionBinding ORDER BY clickCount ASC")
+    fun getAllFlow(): Flow<List<ClickActionBinding>>
+
+    @Query("SELECT * FROM ClickActionBinding WHERE clickCount = :clickCount AND enabled = 1")
+    suspend fun getEnabledByClickCount(clickCount: Int): ClickActionBinding?
+
+    @Query("SELECT * FROM ClickActionBinding WHERE clickCount = :clickCount")
+    suspend fun getByClickCount(clickCount: Int): ClickActionBinding?
+
+    @Insert
+    suspend fun insert(binding: ClickActionBinding): Long
+
+    @Update
+    suspend fun update(binding: ClickActionBinding)
+
+    @Query("DELETE FROM ClickActionBinding WHERE id = :id")
+    suspend fun delete(id: Long)
+}

--- a/experimental/src/commonMain/kotlin/coredevices/ring/database/room/repository/ClickActionRepository.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/database/room/repository/ClickActionRepository.kt
@@ -1,0 +1,46 @@
+package coredevices.ring.database.room.repository
+
+import coredevices.ring.data.entity.room.ClickActionBinding
+import coredevices.ring.database.room.dao.ClickActionBindingDao
+import kotlinx.coroutines.flow.Flow
+
+class ClickActionRepository(private val dao: ClickActionBindingDao) {
+
+    fun bindingsFlow(): Flow<List<ClickActionBinding>> = dao.getAllFlow()
+
+    suspend fun enabledBindingFor(clickCount: Int): ClickActionBinding? =
+        dao.getEnabledByClickCount(clickCount)
+
+    /**
+     * Inserts or updates [binding]. Click counts are unique, so a count already owned by a
+     * different binding is rejected rather than allowed to fail on the unique index.
+     */
+    suspend fun save(binding: ClickActionBinding): SaveResult {
+        if (binding.clickCount !in ClickActionBinding.CLICK_COUNT_RANGE) {
+            return SaveResult.ClickCountOutOfRange
+        }
+        val existing = dao.getByClickCount(binding.clickCount)
+        if (existing != null && existing.id != binding.id) {
+            return SaveResult.ClickCountTaken
+        }
+        // The check above is not atomic with the write, and clickCount is uniquely indexed, so
+        // a concurrent save can still lose the race — surface it rather than crash the caller.
+        return runCatching {
+            if (binding.id == 0L) {
+                SaveResult.Saved(dao.insert(binding))
+            } else {
+                dao.update(binding)
+                SaveResult.Saved(binding.id)
+            }
+        }.getOrElse { SaveResult.Failed(it.message ?: "Couldn't save the click action") }
+    }
+
+    suspend fun delete(id: Long) = dao.delete(id)
+
+    sealed interface SaveResult {
+        data class Saved(val id: Long) : SaveResult
+        data object ClickCountTaken : SaveResult
+        data object ClickCountOutOfRange : SaveResult
+        data class Failed(val message: String) : SaveResult
+    }
+}

--- a/experimental/src/commonMain/kotlin/coredevices/ring/database/room/repository/McpSandboxRepository.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/database/room/repository/McpSandboxRepository.kt
@@ -35,6 +35,10 @@ class McpSandboxRepository(
         return groupDao.getAllFlow().first().first().id
     }
 
+    /** Null when every group has been deleted, which the groups screen permits. */
+    suspend fun getDefaultGroupIdOrNull(): Long? =
+        groupDao.getAllFlow().first().firstOrNull()?.id
+
     suspend fun updateGroupModelType(groupId: Long, modelType: SandboxModelType) {
         groupDao.updateModelType(groupId, modelType)
     }

--- a/experimental/src/commonMain/kotlin/coredevices/ring/external/indexwebhook/IndexWebhookApi.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/external/indexwebhook/IndexWebhookApi.kt
@@ -43,9 +43,21 @@ interface IndexWebhookApi {
     val isEnabled: StateFlow<Boolean>
 }
 
-enum class IndexWebhookRecordingTrigger(val headerValue: String) {
-    SingleClickHold("single-click-hold"),
-    DoubleClickHold("double-click-hold"),
+sealed interface IndexWebhookRecordingTrigger {
+    val headerValue: String
+
+    data object SingleClickHold : IndexWebhookRecordingTrigger {
+        override val headerValue = "single-click-hold"
+    }
+
+    data object DoubleClickHold : IndexWebhookRecordingTrigger {
+        override val headerValue = "double-click-hold"
+    }
+
+    /** Fired by a custom click-count binding rather than a recording gesture. */
+    data class Clicks(val count: Int) : IndexWebhookRecordingTrigger {
+        override val headerValue = "$count-clicks"
+    }
 }
 
 /**

--- a/experimental/src/commonMain/kotlin/coredevices/ring/service/ClickActionExecutor.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/service/ClickActionExecutor.kt
@@ -1,23 +1,97 @@
 package coredevices.ring.service
 
 import co.touchlab.kermit.Logger
+import coredevices.mcp.SessionContext
+import coredevices.mcp.data.SemanticResult
+import coredevices.ring.agent.McpSessionFactory
 import coredevices.ring.data.entity.room.ClickAction
 import coredevices.ring.data.entity.room.ClickActionBinding
+import coredevices.ring.database.room.repository.ItemRepository
+import coredevices.ring.database.room.repository.McpSandboxRepository
+import coredevices.ring.service.indexfeed.ItemFactory
 import coredevices.ring.service.recordings.RecordingProcessingQueue
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.seconds
 
-/** Runs the action bound to a custom click gesture. */
+/**
+ * Runs the action bound to a custom click gesture. Unlike a recording, there is no transcript
+ * and no agent turn, so tool calls are dispatched directly with the arguments the user
+ * configured and the outcome is logged to the feed here rather than by
+ * [coredevices.ring.service.recordings.RecordingProcessor].
+ */
 class ClickActionExecutor(
+    private val mcpSessionFactory: McpSessionFactory,
+    private val mcpSandboxRepository: McpSandboxRepository,
     private val recordingProcessingQueue: RecordingProcessingQueue,
+    private val itemFactory: ItemFactory,
+    private val itemRepository: ItemRepository,
 ) {
     companion object {
         private val logger = Logger.withTag("ClickActionExecutor")
+        private val SESSION_CLOSE_TIMEOUT = 3.seconds
     }
 
     suspend fun execute(binding: ClickActionBinding) {
         when (val action = binding.action) {
             is ClickAction.AgentText -> recordingProcessingQueue.queueTextProcessing(action.text)
+            is ClickAction.ToolCall -> runTool(action, binding.clickCount)
             ClickAction.Unsupported ->
                 logger.w { "${binding.clickCount} clicks is bound to an unreadable action; ignoring" }
         }
+    }
+
+    private suspend fun runTool(action: ClickAction.ToolCall, clickCount: Int) = coroutineScope {
+        val groupId = mcpSandboxRepository.getDefaultGroupIdOrNull()
+            ?: error("No MCP sandbox group configured")
+        val session = mcpSessionFactory.createForDirectToolCall(
+            groupId,
+            this,
+            onlyIntegration = action.integrationName,
+        )
+        session.openSession()
+        val result = try {
+            session.callTool(
+                integrationName = action.integrationName,
+                toolName = action.toolName,
+                jsonInput = action.arguments,
+                context = SessionContext(
+                    // No recording to anchor to, so relative times resolve against now.
+                    timeBase = Clock.System.now(),
+                    // Already completed: a tool awaiting this must not block on a gesture
+                    // that carries no speech.
+                    userMessageText = CompletableDeferred<String?>().apply { complete(null) },
+                ),
+            )
+        } finally {
+            // NonCancellable so a cancelled click action still releases the connection.
+            withContext(NonCancellable) {
+                withTimeout(SESSION_CLOSE_TIMEOUT) { session.closeSession() }
+            }
+        }
+        logger.i { "$clickCount clicks ran ${action.integrationName}/${action.toolName}: ${result.semanticResult}" }
+        logToFeed(action, result.semanticResult)
+    }
+
+    private suspend fun logToFeed(action: ClickAction.ToolCall, semanticResult: SemanticResult?) {
+        // Tools that create their own item (notes, reminders) have already done so; adding an
+        // action log for those would double up in the feed.
+        if (semanticResult is SemanticResult.ListItemCreation || semanticResult is SemanticResult.TaskCreation) return
+        val failure = semanticResult as? SemanticResult.GenericFailure
+        val item = itemFactory.actionLogItem(
+            sourceRecordingId = null,
+            createdAt = Clock.System.now(),
+            title = action.toolName,
+            toolName = "${action.integrationName}/${action.toolName}",
+            success = failure == null,
+            toolCallId = null,
+            body = failure?.userErrorMessage.orEmpty(),
+        )
+        runCatching { itemRepository.setItem(itemFactory.simpleUid(), item) }
+            .onFailure { logger.e(it) { "Failed to log click action to feed" } }
     }
 }

--- a/experimental/src/commonMain/kotlin/coredevices/ring/service/ClickActionExecutor.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/service/ClickActionExecutor.kt
@@ -8,6 +8,8 @@ import coredevices.ring.data.entity.room.ClickAction
 import coredevices.ring.data.entity.room.ClickActionBinding
 import coredevices.ring.database.room.repository.ItemRepository
 import coredevices.ring.database.room.repository.McpSandboxRepository
+import coredevices.ring.external.indexwebhook.IndexWebhookApi
+import coredevices.ring.external.indexwebhook.IndexWebhookRecordingTrigger
 import coredevices.ring.service.indexfeed.ItemFactory
 import coredevices.ring.service.recordings.RecordingProcessingQueue
 import kotlinx.coroutines.CompletableDeferred
@@ -28,6 +30,7 @@ class ClickActionExecutor(
     private val mcpSessionFactory: McpSessionFactory,
     private val mcpSandboxRepository: McpSandboxRepository,
     private val recordingProcessingQueue: RecordingProcessingQueue,
+    private val webhookApi: IndexWebhookApi,
     private val itemFactory: ItemFactory,
     private val itemRepository: ItemRepository,
 ) {
@@ -42,6 +45,16 @@ class ClickActionExecutor(
             is ClickAction.ToolCall -> runTool(action, binding.clickCount)
             ClickAction.Unsupported ->
                 logger.w { "${binding.clickCount} clicks is bound to an unreadable action; ignoring" }
+            // No trigger check here: unlike a recording, the binding itself is the user's
+            // explicit opt-in, so IndexWebhookPreferences.trigger doesn't apply.
+            ClickAction.Webhook -> webhookApi.uploadIfEnabled(
+                samples = null,
+                sampleRate = RingSync.TARGET_SAMPLE_RATE,
+                recordingId = "clicks-${binding.clickCount}-${Clock.System.now()}",
+                transcription = null,
+                recordedAt = Clock.System.now(),
+                trigger = IndexWebhookRecordingTrigger.Clicks(binding.clickCount),
+            )
         }
     }
 

--- a/experimental/src/commonMain/kotlin/coredevices/ring/service/ClickActionExecutor.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/service/ClickActionExecutor.kt
@@ -1,0 +1,23 @@
+package coredevices.ring.service
+
+import co.touchlab.kermit.Logger
+import coredevices.ring.data.entity.room.ClickAction
+import coredevices.ring.data.entity.room.ClickActionBinding
+import coredevices.ring.service.recordings.RecordingProcessingQueue
+
+/** Runs the action bound to a custom click gesture. */
+class ClickActionExecutor(
+    private val recordingProcessingQueue: RecordingProcessingQueue,
+) {
+    companion object {
+        private val logger = Logger.withTag("ClickActionExecutor")
+    }
+
+    suspend fun execute(binding: ClickActionBinding) {
+        when (val action = binding.action) {
+            is ClickAction.AgentText -> recordingProcessingQueue.queueTextProcessing(action.text)
+            ClickAction.Unsupported ->
+                logger.w { "${binding.clickCount} clicks is bound to an unreadable action; ignoring" }
+        }
+    }
+}

--- a/experimental/src/commonMain/kotlin/coredevices/ring/service/ClickActionToolCatalog.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/service/ClickActionToolCatalog.kt
@@ -1,0 +1,58 @@
+package coredevices.ring.service
+
+import coredevices.ring.agent.McpSessionFactory
+import coredevices.ring.database.room.repository.McpSandboxRepository
+import io.modelcontextprotocol.kotlin.sdk.types.Tool
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.time.Duration.Companion.seconds
+
+/** A tool the user can bind a click gesture to, with the schema its arguments must satisfy. */
+data class CatalogTool(
+    val integrationName: String,
+    val definition: Tool,
+) {
+    val toolName: String get() = definition.name
+}
+
+/**
+ * Lists every tool a click binding can call — built-in servlets and HTTP MCP servers alike,
+ * from the default sandbox group. Listing HTTP servers is a network round trip, so callers
+ * should treat this as a loading operation.
+ */
+class ClickActionToolCatalog(
+    private val mcpSessionFactory: McpSessionFactory,
+    private val mcpSandboxRepository: McpSandboxRepository,
+) {
+    companion object {
+        private val SESSION_CLOSE_TIMEOUT = 3.seconds
+
+        /** Nothing downstream of an MCP server bounds its own connect/list, so bound it here. */
+        private val LIST_TIMEOUT = 20.seconds
+    }
+
+    suspend fun availableTools(): List<CatalogTool> {
+        val groupId = mcpSandboxRepository.getDefaultGroupIdOrNull()
+            ?: error("No MCP sandbox group configured")
+        return withTimeoutOrNull(LIST_TIMEOUT) { loadTools(groupId) }
+            ?: error("Timed out after $LIST_TIMEOUT waiting for MCP servers")
+    }
+
+    private suspend fun loadTools(groupId: Long): List<CatalogTool> = coroutineScope {
+        val session = mcpSessionFactory.createForDirectToolCall(groupId, this)
+        session.openSession()
+        try {
+            session.listTools()
+                .map { CatalogTool(it.integrationName, it.tool.definition) }
+                .sortedWith(compareBy({ it.integrationName }, { it.toolName }))
+        } finally {
+            // NonCancellable so the timeout above still releases the connections.
+            withContext(NonCancellable) {
+                withTimeout(SESSION_CLOSE_TIMEOUT) { session.closeSession() }
+            }
+        }
+    }
+}

--- a/experimental/src/commonMain/kotlin/coredevices/ring/service/IndexButtonActionHandler.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/service/IndexButtonActionHandler.kt
@@ -1,10 +1,47 @@
 package coredevices.ring.service
 
 import co.touchlab.kermit.Logger
+import coredevices.ring.data.entity.room.ClickActionBinding
 import coredevices.ring.database.MusicControlMode
 import coredevices.ring.database.Preferences
+import coredevices.ring.database.reservedClickCounts
+import coredevices.ring.database.room.repository.ClickActionRepository
+import kotlinx.coroutines.launch
+import kotlin.coroutines.cancellation.CancellationException
 
-class IndexButtonActionHandler(prefs: Preferences, sequenceRecorder: IndexButtonSequenceRecorder) {
+/** What a debounced button sequence should trigger. */
+internal sealed interface ButtonDispatch {
+    data object Ignore : ButtonDispatch
+    data class Media(val presses: List<ButtonPress>) : ButtonDispatch
+    data class Custom(val clickCount: Int) : ButtonDispatch
+}
+
+/**
+ * Precedence rule for a debounced sequence, kept pure so it can be tested without the platform
+ * media calls. Media control wins over a custom binding — a binding on a media-owned count
+ * would never fire, which is why the settings UI locks those counts.
+ */
+internal fun resolveButtonDispatch(
+    presses: List<ButtonPress>,
+    reservedByMedia: Set<Int>,
+): ButtonDispatch {
+    // A long press means a recording gesture, owned by the recording pipeline.
+    if (presses.isEmpty() || presses.any { it != ButtonPress.Short }) return ButtonDispatch.Ignore
+    val clickCount = presses.size
+    return when {
+        clickCount in reservedByMedia -> ButtonDispatch.Media(presses)
+        clickCount in ClickActionBinding.CLICK_COUNT_RANGE -> ButtonDispatch.Custom(clickCount)
+        else -> ButtonDispatch.Ignore
+    }
+}
+
+class IndexButtonActionHandler(
+    private val prefs: Preferences,
+    sequenceRecorder: IndexButtonSequenceRecorder,
+    private val clickActionRepository: ClickActionRepository,
+    private val clickActionExecutor: ClickActionExecutor,
+    private val scope: RecordingBackgroundScope,
+) {
     companion object {
         private val logger = Logger.withTag("IndexButtonActionHandler")
     }
@@ -32,10 +69,32 @@ class IndexButtonActionHandler(prefs: Preferences, sequenceRecorder: IndexButton
 
     suspend fun handleButtonActions() {
         sequenceEvents.collect { buttonPresses ->
-            val action = actions[buttonPresses]
-            action?.invoke()?.let {
-                logger.i("Handled button action for sequence: ${buttonPresses.joinToString(", ") { it.name }}")
+            val reserved = prefs.musicControlMode.value.reservedClickCounts()
+            when (val dispatch = resolveButtonDispatch(buttonPresses, reserved)) {
+                ButtonDispatch.Ignore -> {}
+                is ButtonDispatch.Media -> {
+                    actions[dispatch.presses]?.invoke()
+                    logger.i { "Handled media action for ${dispatch.presses.size} click(s)" }
+                }
+                is ButtonDispatch.Custom -> {
+                    // Dispatched off the collector: an action can take seconds (agent
+                    // inference, MCP connects) and awaiting it here would delay or drop the
+                    // next gesture, media control included.
+                    scope.launch { runClickAction(dispatch.clickCount) }
+                }
             }
+        }
+    }
+
+    private suspend fun runClickAction(clickCount: Int) {
+        val binding = clickActionRepository.enabledBindingFor(clickCount) ?: return
+        try {
+            clickActionExecutor.execute(binding)
+            logger.i { "Handled click action for $clickCount click(s): ${binding.action}" }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logger.e(e) { "Click action for $clickCount click(s) failed" }
         }
     }
 }

--- a/experimental/src/commonMain/kotlin/coredevices/ring/service/indexfeed/ItemFactory.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/service/indexfeed/ItemFactory.kt
@@ -186,7 +186,7 @@ class ItemFactory {
     )
 
     fun actionLogItem(
-        sourceRecordingId: String,
+        sourceRecordingId: String?,
         createdAt: Instant,
         title: String,
         toolName: String,

--- a/experimental/src/commonMain/kotlin/coredevices/ring/ui/navigation/RingRoutes.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/ui/navigation/RingRoutes.kt
@@ -19,6 +19,7 @@ import coredevices.ring.ui.screens.settings.IndexSettings
 import kotlinx.serialization.Serializable
 import coredevices.ring.ui.screens.RingSyncInspectorScreen
 import coredevices.ring.ui.screens.settings.AddIntegration
+import coredevices.ring.ui.screens.settings.clickactions.ClickActions
 import coredevices.ring.ui.screens.settings.mcp.McpSandboxGroups
 
 /** Marker for routes that belong to the Index/Ring feature. The
@@ -57,6 +58,9 @@ object RingRoutes {
     data object McpSandboxGroups : RingRoute
     @Serializable
     data object AddIntegration : RingRoute
+    /** Custom short-click gesture bindings. */
+    @Serializable
+    data object ClickActions : RingRoute
 
     /** Deep link that opens the [ObjectDetails] screen for an index item by
      *  its Firestore id. Used by the platform reminder notification so
@@ -115,6 +119,9 @@ fun NavGraphBuilder.addRingRoutes(coreNav: CoreNav) {
     }
     composable<RingRoutes.RingSyncInspector> {
         RingSyncInspectorScreen(coreNav)
+    }
+    composable<RingRoutes.ClickActions> {
+        ClickActions(coreNav)
     }
     composable<RingRoutes.McpSandboxGroups> {
         McpSandboxGroups(coreNav)

--- a/experimental/src/commonMain/kotlin/coredevices/ring/ui/screens/settings/IndexSettings.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/ui/screens/settings/IndexSettings.kt
@@ -417,6 +417,24 @@ fun IndexSettings(coreNav: CoreNav) {
                     }
                 )
             }
+            item {
+                val clickActions by viewModel.clickActionBindings.collectAsState()
+                ListItem(
+                    modifier = Modifier.clickable {
+                        coreNav.navigateTo(RingRoutes.ClickActions)
+                    },
+                    headlineContent = { Text("Custom click actions") },
+                    supportingContent = {
+                        Text(
+                            if (clickActions.isEmpty()) {
+                                "None"
+                            } else {
+                                clickActions.joinToString(" · ") { "${it.clickCount} clicks" }
+                            }
+                        )
+                    }
+                )
+            }
 
             // --- Accounts section ---
             item {

--- a/experimental/src/commonMain/kotlin/coredevices/ring/ui/screens/settings/clickactions/ClickActions.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/ui/screens/settings/clickactions/ClickActions.kt
@@ -1,0 +1,317 @@
+package coredevices.ring.ui.screens.settings.clickactions
+
+import CoreNav
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material3.ExtendedFloatingActionButton
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import coreapp.util.generated.resources.Res
+import coreapp.util.generated.resources.back
+import coredevices.ring.data.entity.room.ClickAction
+import coredevices.ring.data.entity.room.ClickActionBinding
+import coredevices.ui.M3Dialog
+import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.viewmodel.koinViewModel
+
+@Composable
+fun ClickActions(coreNav: CoreNav) {
+    val viewModel = koinViewModel<ClickActionsViewModel>()
+    val bindings by viewModel.bindings.collectAsState()
+    val reserved by viewModel.reservedClickCounts.collectAsState()
+    val error by viewModel.error.collectAsState()
+
+    var editing by remember { mutableStateOf<ClickActionBinding?>(null) }
+    var pendingDelete by remember { mutableStateOf<ClickActionBinding?>(null) }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Custom click actions") },
+                navigationIcon = {
+                    IconButton(onClick = { coreNav.goBack() }) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, stringResource(Res.string.back))
+                    }
+                },
+            )
+        },
+        floatingActionButton = {
+            val free = clickCountOptions(bindings, reserved, editingId = 0L).firstSelectable()
+            if (free != null) {
+                ExtendedFloatingActionButton(
+                    onClick = {
+                        editing = ClickActionBinding(
+                            clickCount = free,
+                            action = ClickAction.AgentText(""),
+                        )
+                    },
+                    icon = { Icon(Icons.Default.Add, contentDescription = null) },
+                    text = { Text("Add") },
+                )
+            }
+        },
+    ) { padding ->
+        LazyColumn(
+            modifier = Modifier.fillMaxSize().padding(padding),
+            contentPadding = PaddingValues(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            item {
+                Text(
+                    "Short clicks on Index 01 that don't start a recording. Counts already used " +
+                        "by media control are locked.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            if (bindings.isEmpty()) {
+                item {
+                    Text(
+                        "No click actions yet.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            items(bindings, key = { it.id }) { binding ->
+                BindingCard(
+                    binding = binding,
+                    shadowedByMedia = binding.clickCount in reserved,
+                    onClick = { editing = binding },
+                    onDelete = { pendingDelete = binding },
+                )
+            }
+        }
+    }
+
+    editing?.let { target ->
+        ClickActionEditorDialog(
+            binding = target,
+            clickCountOptions = clickCountOptions(bindings, reserved, editingId = target.id),
+            onDismiss = { editing = null },
+            onSave = { updated -> viewModel.save(updated) { editing = null } },
+        )
+    }
+
+    pendingDelete?.let { target ->
+        M3Dialog(
+            onDismissRequest = { pendingDelete = null },
+            title = { Text("Remove click action") },
+            buttons = {
+                TextButton(onClick = { pendingDelete = null }) { Text("Cancel") }
+                Spacer(Modifier.width(8.dp))
+                TextButton(onClick = {
+                    viewModel.delete(target.id)
+                    pendingDelete = null
+                }) { Text("Remove") }
+            },
+        ) {
+            Text("${target.clickCount} clicks will no longer do anything.")
+        }
+    }
+
+    error?.let { message ->
+        M3Dialog(
+            onDismissRequest = { viewModel.clearError() },
+            title = { Text("Couldn't save") },
+            buttons = { TextButton(onClick = { viewModel.clearError() }) { Text("OK") } },
+        ) {
+            Text(message)
+        }
+    }
+}
+
+@Composable
+private fun BindingCard(
+    binding: ClickActionBinding,
+    shadowedByMedia: Boolean,
+    onClick: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    OutlinedCard(modifier = Modifier.fillMaxWidth().clickable(onClick = onClick)) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    "${binding.clickCount} clicks",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                Text(
+                    binding.action.summary(),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                if (!binding.enabled) {
+                    Text(
+                        "Disabled",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                } else if (shadowedByMedia) {
+                    Text(
+                        "Won't fire — media control uses this many clicks",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                }
+            }
+            IconButton(onClick = onDelete) {
+                Icon(Icons.Default.Delete, contentDescription = "Remove")
+            }
+        }
+    }
+}
+
+private fun ClickAction.summary(): String = when (this) {
+    is ClickAction.AgentText -> "Ask the agent · \"$text\""
+    ClickAction.Unsupported -> "Unreadable — open to replace it"
+}
+
+@Composable
+private fun ClickActionEditorDialog(
+    binding: ClickActionBinding,
+    clickCountOptions: List<ClickCountOption>,
+    onDismiss: () -> Unit,
+    onSave: (ClickActionBinding) -> Unit,
+) {
+    var clickCount by remember(binding.id) { mutableStateOf(binding.clickCount) }
+    var enabled by remember(binding.id) { mutableStateOf(binding.enabled) }
+    var agentText by remember(binding.id) {
+        mutableStateOf((binding.action as? ClickAction.AgentText)?.text.orEmpty())
+    }
+
+    val canSave = agentText.isNotBlank() &&
+        clickCountOptions.any { it.count == clickCount && it.selectable }
+
+    M3Dialog(
+        onDismissRequest = onDismiss,
+        title = { Text(if (binding.id == 0L) "New click action" else "Edit click action") },
+        scrollableContent = true,
+        buttons = {
+            TextButton(onClick = onDismiss) { Text("Cancel") }
+            Spacer(Modifier.width(8.dp))
+            TextButton(
+                enabled = canSave,
+                onClick = {
+                    onSave(
+                        binding.copy(
+                            clickCount = clickCount,
+                            action = ClickAction.AgentText(agentText.trim()),
+                            enabled = enabled,
+                        )
+                    )
+                },
+            ) { Text("Save") }
+        },
+    ) {
+        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            SectionLabel("Clicks")
+            FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                clickCountOptions.forEach { option ->
+                    FilterChip(
+                        selected = option.count == clickCount,
+                        enabled = option.selectable,
+                        onClick = { clickCount = option.count },
+                        label = { Text("${option.count}") },
+                        leadingIcon = if (option.selectable) null else {
+                            { Icon(Icons.Default.Lock, contentDescription = "Unavailable") }
+                        },
+                    )
+                }
+            }
+            ClickCountLegend(clickCountOptions)
+
+            HorizontalDivider()
+            SectionLabel("Action")
+            OutlinedTextField(
+                value = agentText,
+                onValueChange = { agentText = it },
+                label = { Text("What to send") },
+                supportingText = { Text("Ending with '?' routes it to search.") },
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            HorizontalDivider()
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text("Enabled", modifier = Modifier.weight(1f))
+                Switch(checked = enabled, onCheckedChange = { enabled = it })
+            }
+        }
+    }
+}
+
+/** Explains any locked counts, so a missing option never looks like a bug. */
+@Composable
+private fun ClickCountLegend(options: List<ClickCountOption>) {
+    val byMedia = options.filter { it.availability == ClickCountAvailability.UsedByMediaControl }
+    val byAction = options.filter { it.availability == ClickCountAvailability.UsedByAnotherAction }
+    if (byMedia.isEmpty() && byAction.isEmpty()) return
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        if (byMedia.isNotEmpty()) {
+            Text(
+                "${byMedia.joinToString(", ") { it.count.toString() }} used by media control. " +
+                    "Change Music play/pause in Index settings to free them.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        if (byAction.isNotEmpty()) {
+            Text(
+                "${byAction.joinToString(", ") { it.count.toString() }} already bound to another action.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun SectionLabel(text: String) {
+    Text(
+        text,
+        style = MaterialTheme.typography.labelLarge,
+        color = MaterialTheme.colorScheme.primary,
+    )
+}

--- a/experimental/src/commonMain/kotlin/coredevices/ring/ui/screens/settings/clickactions/ClickActions.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/ui/screens/settings/clickactions/ClickActions.kt
@@ -3,22 +3,25 @@ package coredevices.ring.ui.screens.settings.clickactions
 import CoreNav
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
@@ -27,12 +30,14 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -41,11 +46,13 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import coreapp.util.generated.resources.Res
 import coreapp.util.generated.resources.back
 import coredevices.ring.data.entity.room.ClickAction
 import coredevices.ring.data.entity.room.ClickActionBinding
+import coredevices.ring.service.CatalogTool
 import coredevices.ui.M3Dialog
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
@@ -55,6 +62,7 @@ fun ClickActions(coreNav: CoreNav) {
     val viewModel = koinViewModel<ClickActionsViewModel>()
     val bindings by viewModel.bindings.collectAsState()
     val reserved by viewModel.reservedClickCounts.collectAsState()
+    val catalog by viewModel.catalog.collectAsState()
     val error by viewModel.error.collectAsState()
 
     var editing by remember { mutableStateOf<ClickActionBinding?>(null) }
@@ -121,9 +129,12 @@ fun ClickActions(coreNav: CoreNav) {
     }
 
     editing?.let { target ->
+        LaunchedEffect(target.id) { viewModel.loadTools() }
         ClickActionEditorDialog(
             binding = target,
             clickCountOptions = clickCountOptions(bindings, reserved, editingId = target.id),
+            catalog = catalog,
+            onRetryTools = { viewModel.loadTools(force = true) },
             onDismiss = { editing = null },
             onSave = { updated -> viewModel.save(updated) { editing = null } },
         )
@@ -203,24 +214,59 @@ private fun BindingCard(
 
 private fun ClickAction.summary(): String = when (this) {
     is ClickAction.AgentText -> "Ask the agent · \"$text\""
+    is ClickAction.ToolCall -> "Run tool · $integrationName/$toolName"
     ClickAction.Unsupported -> "Unreadable — open to replace it"
+}
+
+private enum class ActionKind { Agent, Tool }
+
+private fun ClickAction.kind(): ActionKind = when (this) {
+    is ClickAction.AgentText -> ActionKind.Agent
+    is ClickAction.ToolCall -> ActionKind.Tool
+    // Nothing to restore, so open on the simplest form and make the user re-pick.
+    ClickAction.Unsupported -> ActionKind.Agent
 }
 
 @Composable
 private fun ClickActionEditorDialog(
     binding: ClickActionBinding,
     clickCountOptions: List<ClickCountOption>,
+    catalog: ToolCatalogState,
+    onRetryTools: () -> Unit,
     onDismiss: () -> Unit,
     onSave: (ClickActionBinding) -> Unit,
 ) {
     var clickCount by remember(binding.id) { mutableStateOf(binding.clickCount) }
     var enabled by remember(binding.id) { mutableStateOf(binding.enabled) }
+    var kind by remember(binding.id) { mutableStateOf(binding.action.kind()) }
     var agentText by remember(binding.id) {
         mutableStateOf((binding.action as? ClickAction.AgentText)?.text.orEmpty())
     }
+    var selectedTool by remember(binding.id) { mutableStateOf<CatalogTool?>(null) }
+    var paramValues by remember(binding.id) { mutableStateOf(emptyMap<String, String>()) }
+    var showToolPicker by remember { mutableStateOf(false) }
 
-    val canSave = agentText.isNotBlank() &&
-        clickCountOptions.any { it.count == clickCount && it.selectable }
+    // Re-attach a saved tool to its live schema once the catalog arrives, so an existing
+    // binding opens with its arguments filled in rather than blank.
+    val existingToolCall = binding.action as? ClickAction.ToolCall
+    LaunchedEffect(catalog, binding.id) {
+        if (existingToolCall == null || selectedTool != null) return@LaunchedEffect
+        val tools = (catalog as? ToolCatalogState.Loaded)?.tools ?: return@LaunchedEffect
+        val match = tools.firstOrNull {
+            it.integrationName == existingToolCall.integrationName &&
+                it.toolName == existingToolCall.toolName
+        } ?: return@LaunchedEffect
+        selectedTool = match
+        paramValues = existingToolCall.arguments.toFormValues(match.definition.parameterFields())
+    }
+
+    val fields = selectedTool?.definition?.parameterFields().orEmpty()
+    val missing = missingRequired(fields, paramValues)
+    val badJson = invalidJsonFields(fields, paramValues)
+    val canSave = when (kind) {
+        ActionKind.Agent -> agentText.isNotBlank()
+        ActionKind.Tool -> selectedTool != null && missing.isEmpty() && badJson.isEmpty()
+    } && clickCountOptions.any { it.count == clickCount && it.selectable }
 
     M3Dialog(
         onDismissRequest = onDismiss,
@@ -232,13 +278,17 @@ private fun ClickActionEditorDialog(
             TextButton(
                 enabled = canSave,
                 onClick = {
-                    onSave(
-                        binding.copy(
-                            clickCount = clickCount,
-                            action = ClickAction.AgentText(agentText.trim()),
-                            enabled = enabled,
-                        )
-                    )
+                    val action = when (kind) {
+                        ActionKind.Agent -> ClickAction.AgentText(agentText.trim())
+                        ActionKind.Tool -> selectedTool!!.let {
+                            ClickAction.ToolCall(
+                                integrationName = it.integrationName,
+                                toolName = it.toolName,
+                                arguments = buildArguments(fields, paramValues),
+                            )
+                        }
+                    }
+                    onSave(binding.copy(clickCount = clickCount, action = action, enabled = enabled))
                 },
             ) { Text("Save") }
         },
@@ -262,13 +312,63 @@ private fun ClickActionEditorDialog(
 
             HorizontalDivider()
             SectionLabel("Action")
-            OutlinedTextField(
-                value = agentText,
-                onValueChange = { agentText = it },
-                label = { Text("What to send") },
-                supportingText = { Text("Ending with '?' routes it to search.") },
-                modifier = Modifier.fillMaxWidth(),
-            )
+            ActionKind.entries.forEach { option ->
+                Row(
+                    modifier = Modifier.fillMaxWidth().clickable { kind = option },
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    RadioButton(selected = kind == option, onClick = { kind = option })
+                    Spacer(Modifier.width(8.dp))
+                    Text(
+                        when (option) {
+                            ActionKind.Agent -> "Ask the agent"
+                            ActionKind.Tool -> "Run a tool"
+                        }
+                    )
+                }
+            }
+
+            when (kind) {
+                ActionKind.Agent -> {
+                    OutlinedTextField(
+                        value = agentText,
+                        onValueChange = { agentText = it },
+                        label = { Text("What to send") },
+                        supportingText = { Text("Ending with '?' routes it to search.") },
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+                ActionKind.Tool -> {
+                    ToolSelector(
+                        catalog = catalog,
+                        selected = selectedTool,
+                        onPick = { showToolPicker = true },
+                        onRetry = onRetryTools,
+                    )
+                    if (existingToolCall != null && selectedTool == null &&
+                        catalog is ToolCatalogState.Loaded
+                    ) {
+                        Text(
+                            "${existingToolCall.integrationName}/${existingToolCall.toolName} " +
+                                "is no longer available. Pick another tool — the saved " +
+                                "parameters can't be kept.",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.error,
+                        )
+                    }
+                    if (fields.isNotEmpty()) {
+                        SectionLabel("Parameters")
+                        fields.forEach { field ->
+                            ToolParameterInput(
+                                field = field,
+                                value = paramValues[field.name].orEmpty(),
+                                isInvalidJson = field.name in badJson,
+                                onValueChange = { paramValues = paramValues + (field.name to it) },
+                            )
+                        }
+                    }
+                }
+            }
 
             HorizontalDivider()
             Row(
@@ -279,6 +379,18 @@ private fun ClickActionEditorDialog(
                 Switch(checked = enabled, onCheckedChange = { enabled = it })
             }
         }
+    }
+
+    if (showToolPicker && catalog is ToolCatalogState.Loaded) {
+        ToolPickerDialog(
+            tools = catalog.tools,
+            onDismiss = { showToolPicker = false },
+            onSelect = { tool ->
+                selectedTool = tool
+                paramValues = emptyMap()
+                showToolPicker = false
+            },
+        )
     }
 }
 
@@ -314,4 +426,164 @@ private fun SectionLabel(text: String) {
         style = MaterialTheme.typography.labelLarge,
         color = MaterialTheme.colorScheme.primary,
     )
+}
+
+@Composable
+private fun ToolSelector(
+    catalog: ToolCatalogState,
+    selected: CatalogTool?,
+    onPick: () -> Unit,
+    onRetry: () -> Unit,
+) {
+    when (catalog) {
+        ToolCatalogState.Idle, ToolCatalogState.Loading -> Row(
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            CircularProgressIndicator(modifier = Modifier.height(20.dp).width(20.dp))
+            Spacer(Modifier.width(12.dp))
+            Text("Loading tools…", style = MaterialTheme.typography.bodyMedium)
+        }
+        is ToolCatalogState.Failed -> Column {
+            Text(
+                "Couldn't load tools: ${catalog.message}",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.error,
+            )
+            TextButton(onClick = onRetry) { Text("Retry") }
+        }
+        is ToolCatalogState.Loaded -> OutlinedCard(
+            modifier = Modifier.fillMaxWidth().clickable(onClick = onPick),
+        ) {
+            Column(modifier = Modifier.padding(16.dp)) {
+                Text(
+                    selected?.toolName ?: "Select a tool",
+                    style = MaterialTheme.typography.titleSmall,
+                )
+                selected?.let {
+                    Text(
+                        it.integrationName,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ToolPickerDialog(
+    tools: List<CatalogTool>,
+    onDismiss: () -> Unit,
+    onSelect: (CatalogTool) -> Unit,
+) {
+    M3Dialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Select a tool") },
+        scrollableContent = true,
+        buttons = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+    ) {
+        Column {
+            if (tools.isEmpty()) {
+                Text("No tools available. Add an MCP server in Index settings.")
+            }
+            tools.groupBy { it.integrationName }.forEach { (integration, integrationTools) ->
+                Text(
+                    integration.uppercase(),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.padding(top = 12.dp, bottom = 4.dp),
+                )
+                integrationTools.forEach { tool ->
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { onSelect(tool) }
+                            .padding(vertical = 8.dp),
+                    ) {
+                        Text(tool.toolName, style = MaterialTheme.typography.bodyLarge)
+                        tool.definition.description?.let {
+                            Text(
+                                it,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ToolParameterInput(
+    field: ToolParameterField,
+    value: String,
+    isInvalidJson: Boolean,
+    onValueChange: (String) -> Unit,
+) {
+    val label = if (field.required) "${field.name} *" else field.name
+    when (val kind = field.kind) {
+        is ToolParameterField.Kind.Bool -> Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(label)
+                field.description?.let {
+                    Text(
+                        it,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            Switch(
+                checked = value.equals("true", ignoreCase = true),
+                onCheckedChange = { onValueChange(it.toString()) },
+            )
+        }
+        is ToolParameterField.Kind.Choice -> Column {
+            Text(label)
+            field.description?.let {
+                Text(
+                    it,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                kind.options.forEach { option ->
+                    FilterChip(
+                        selected = value == option,
+                        onClick = { onValueChange(option) },
+                        label = { Text(option) },
+                    )
+                }
+            }
+        }
+        else -> OutlinedTextField(
+            value = value,
+            onValueChange = onValueChange,
+            label = { Text(label) },
+            isError = isInvalidJson,
+            singleLine = kind !is ToolParameterField.Kind.Json,
+            keyboardOptions = if (kind is ToolParameterField.Kind.Number) {
+                KeyboardOptions(keyboardType = KeyboardType.Number)
+            } else {
+                KeyboardOptions.Default
+            },
+            supportingText = {
+                Text(
+                    when {
+                        isInvalidJson -> "Not valid JSON"
+                        kind is ToolParameterField.Kind.Json -> field.description ?: "JSON value"
+                        else -> field.description.orEmpty()
+                    }
+                )
+            },
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
 }

--- a/experimental/src/commonMain/kotlin/coredevices/ring/ui/screens/settings/clickactions/ClickActions.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/ui/screens/settings/clickactions/ClickActions.kt
@@ -62,6 +62,7 @@ fun ClickActions(coreNav: CoreNav) {
     val viewModel = koinViewModel<ClickActionsViewModel>()
     val bindings by viewModel.bindings.collectAsState()
     val reserved by viewModel.reservedClickCounts.collectAsState()
+    val webhookConfigured by viewModel.webhookConfigured.collectAsState()
     val catalog by viewModel.catalog.collectAsState()
     val error by viewModel.error.collectAsState()
 
@@ -134,6 +135,7 @@ fun ClickActions(coreNav: CoreNav) {
             binding = target,
             clickCountOptions = clickCountOptions(bindings, reserved, editingId = target.id),
             catalog = catalog,
+            webhookConfigured = webhookConfigured,
             onRetryTools = { viewModel.loadTools(force = true) },
             onDismiss = { editing = null },
             onSave = { updated -> viewModel.save(updated) { editing = null } },
@@ -215,14 +217,16 @@ private fun BindingCard(
 private fun ClickAction.summary(): String = when (this) {
     is ClickAction.AgentText -> "Ask the agent · \"$text\""
     is ClickAction.ToolCall -> "Run tool · $integrationName/$toolName"
+    ClickAction.Webhook -> "Call webhook"
     ClickAction.Unsupported -> "Unreadable — open to replace it"
 }
 
-private enum class ActionKind { Agent, Tool }
+private enum class ActionKind { Agent, Tool, Webhook }
 
 private fun ClickAction.kind(): ActionKind = when (this) {
     is ClickAction.AgentText -> ActionKind.Agent
     is ClickAction.ToolCall -> ActionKind.Tool
+    ClickAction.Webhook -> ActionKind.Webhook
     // Nothing to restore, so open on the simplest form and make the user re-pick.
     ClickAction.Unsupported -> ActionKind.Agent
 }
@@ -232,6 +236,7 @@ private fun ClickActionEditorDialog(
     binding: ClickActionBinding,
     clickCountOptions: List<ClickCountOption>,
     catalog: ToolCatalogState,
+    webhookConfigured: Boolean,
     onRetryTools: () -> Unit,
     onDismiss: () -> Unit,
     onSave: (ClickActionBinding) -> Unit,
@@ -266,6 +271,7 @@ private fun ClickActionEditorDialog(
     val canSave = when (kind) {
         ActionKind.Agent -> agentText.isNotBlank()
         ActionKind.Tool -> selectedTool != null && missing.isEmpty() && badJson.isEmpty()
+        ActionKind.Webhook -> true
     } && clickCountOptions.any { it.count == clickCount && it.selectable }
 
     M3Dialog(
@@ -287,6 +293,7 @@ private fun ClickActionEditorDialog(
                                 arguments = buildArguments(fields, paramValues),
                             )
                         }
+                        ActionKind.Webhook -> ClickAction.Webhook
                     }
                     onSave(binding.copy(clickCount = clickCount, action = action, enabled = enabled))
                 },
@@ -323,6 +330,7 @@ private fun ClickActionEditorDialog(
                         when (option) {
                             ActionKind.Agent -> "Ask the agent"
                             ActionKind.Tool -> "Run a tool"
+                            ActionKind.Webhook -> "Call webhook"
                         }
                     )
                 }
@@ -367,6 +375,22 @@ private fun ClickActionEditorDialog(
                             )
                         }
                     }
+                }
+                ActionKind.Webhook -> {
+                    Text(
+                        if (webhookConfigured) {
+                            "Sends a request with no audio or transcript. The " +
+                                "X-Index-Trigger header will read \"$clickCount-clicks\"."
+                        } else {
+                            "No webhook URL is configured yet — set one in Index settings first."
+                        },
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = if (webhookConfigured) {
+                            MaterialTheme.colorScheme.onSurfaceVariant
+                        } else {
+                            MaterialTheme.colorScheme.error
+                        },
+                    )
                 }
             }
 

--- a/experimental/src/commonMain/kotlin/coredevices/ring/ui/screens/settings/clickactions/ClickActionsViewModel.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/ui/screens/settings/clickactions/ClickActionsViewModel.kt
@@ -6,12 +6,21 @@ import coredevices.ring.data.entity.room.ClickActionBinding
 import coredevices.ring.database.Preferences
 import coredevices.ring.database.reservedClickCounts
 import coredevices.ring.database.room.repository.ClickActionRepository
+import coredevices.ring.service.CatalogTool
+import coredevices.ring.service.ClickActionToolCatalog
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+
+sealed interface ToolCatalogState {
+    data object Idle : ToolCatalogState
+    data object Loading : ToolCatalogState
+    data class Loaded(val tools: List<CatalogTool>) : ToolCatalogState
+    data class Failed(val message: String) : ToolCatalogState
+}
 
 enum class ClickCountAvailability {
     Available,
@@ -48,6 +57,7 @@ fun List<ClickCountOption>.firstSelectable(): Int? =
 
 class ClickActionsViewModel(
     private val repository: ClickActionRepository,
+    private val toolCatalog: ClickActionToolCatalog,
     preferences: Preferences,
 ) : ViewModel() {
 
@@ -63,8 +73,24 @@ class ClickActionsViewModel(
         initialValue = emptySet(),
     )
 
+    private val _catalog = MutableStateFlow<ToolCatalogState>(ToolCatalogState.Idle)
+    val catalog = _catalog.asStateFlow()
+
     private val _error = MutableStateFlow<String?>(null)
     val error = _error.asStateFlow()
+
+    /** Connecting to HTTP MCP servers is a network round trip, so this is explicitly triggered. */
+    fun loadTools(force: Boolean = false) {
+        if (!force && _catalog.value is ToolCatalogState.Loaded) return
+        _catalog.value = ToolCatalogState.Loading
+        viewModelScope.launch {
+            _catalog.value = try {
+                ToolCatalogState.Loaded(toolCatalog.availableTools())
+            } catch (e: Exception) {
+                ToolCatalogState.Failed(e.message ?: "Couldn't load tools")
+            }
+        }
+    }
 
     fun save(binding: ClickActionBinding, onSaved: () -> Unit) {
         viewModelScope.launch {

--- a/experimental/src/commonMain/kotlin/coredevices/ring/ui/screens/settings/clickactions/ClickActionsViewModel.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/ui/screens/settings/clickactions/ClickActionsViewModel.kt
@@ -6,6 +6,7 @@ import coredevices.ring.data.entity.room.ClickActionBinding
 import coredevices.ring.database.Preferences
 import coredevices.ring.database.reservedClickCounts
 import coredevices.ring.database.room.repository.ClickActionRepository
+import coredevices.ring.external.indexwebhook.IndexWebhookPreferences
 import coredevices.ring.service.CatalogTool
 import coredevices.ring.service.ClickActionToolCatalog
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -59,6 +60,7 @@ class ClickActionsViewModel(
     private val repository: ClickActionRepository,
     private val toolCatalog: ClickActionToolCatalog,
     preferences: Preferences,
+    webhookPreferences: IndexWebhookPreferences,
 ) : ViewModel() {
 
     val bindings = repository.bindingsFlow().stateIn(
@@ -71,6 +73,12 @@ class ClickActionsViewModel(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(5_000),
         initialValue = emptySet(),
+    )
+
+    val webhookConfigured = webhookPreferences.webhookUrl.map { !it.isNullOrBlank() }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5_000),
+        initialValue = false,
     )
 
     private val _catalog = MutableStateFlow<ToolCatalogState>(ToolCatalogState.Idle)

--- a/experimental/src/commonMain/kotlin/coredevices/ring/ui/screens/settings/clickactions/ClickActionsViewModel.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/ui/screens/settings/clickactions/ClickActionsViewModel.kt
@@ -1,0 +1,91 @@
+package coredevices.ring.ui.screens.settings.clickactions
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import coredevices.ring.data.entity.room.ClickActionBinding
+import coredevices.ring.database.Preferences
+import coredevices.ring.database.reservedClickCounts
+import coredevices.ring.database.room.repository.ClickActionRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+enum class ClickCountAvailability {
+    Available,
+
+    /** Media control dispatches first, so a binding here would never fire. */
+    UsedByMediaControl,
+    UsedByAnotherAction,
+}
+
+data class ClickCountOption(val count: Int, val availability: ClickCountAvailability) {
+    val selectable: Boolean get() = availability == ClickCountAvailability.Available
+}
+
+/**
+ * Every click count in range, each labelled with why it can or can't be claimed. Unavailable
+ * counts are still returned so the UI can show the reason rather than silently omitting them.
+ */
+fun clickCountOptions(
+    existing: List<ClickActionBinding>,
+    reserved: Set<Int>,
+    editingId: Long,
+): List<ClickCountOption> = ClickActionBinding.CLICK_COUNT_RANGE.map { count ->
+    val availability = when {
+        count in reserved -> ClickCountAvailability.UsedByMediaControl
+        existing.any { it.clickCount == count && it.id != editingId } ->
+            ClickCountAvailability.UsedByAnotherAction
+        else -> ClickCountAvailability.Available
+    }
+    ClickCountOption(count, availability)
+}
+
+fun List<ClickCountOption>.firstSelectable(): Int? =
+    firstOrNull { it.selectable }?.count
+
+class ClickActionsViewModel(
+    private val repository: ClickActionRepository,
+    preferences: Preferences,
+) : ViewModel() {
+
+    val bindings = repository.bindingsFlow().stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5_000),
+        initialValue = emptyList(),
+    )
+
+    val reservedClickCounts = preferences.musicControlMode.map { it.reservedClickCounts() }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5_000),
+        initialValue = emptySet(),
+    )
+
+    private val _error = MutableStateFlow<String?>(null)
+    val error = _error.asStateFlow()
+
+    fun save(binding: ClickActionBinding, onSaved: () -> Unit) {
+        viewModelScope.launch {
+            when (val result = repository.save(binding)) {
+                is ClickActionRepository.SaveResult.Saved -> onSaved()
+                ClickActionRepository.SaveResult.ClickCountTaken ->
+                    _error.value = "${binding.clickCount} clicks is already bound to another action."
+                ClickActionRepository.SaveResult.ClickCountOutOfRange ->
+                    _error.value = "Pick between ${ClickActionBinding.MIN_CLICK_COUNT} and " +
+                        "${ClickActionBinding.MAX_CLICK_COUNT} clicks."
+                is ClickActionRepository.SaveResult.Failed ->
+                    _error.value = result.message
+            }
+        }
+    }
+
+    fun delete(id: Long) {
+        viewModelScope.launch { repository.delete(id) }
+    }
+
+    fun clearError() {
+        _error.value = null
+    }
+}

--- a/experimental/src/commonMain/kotlin/coredevices/ring/ui/screens/settings/clickactions/ToolParameterSchema.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/ui/screens/settings/clickactions/ToolParameterSchema.kt
@@ -1,0 +1,119 @@
+package coredevices.ring.ui.screens.settings.clickactions
+
+import io.modelcontextprotocol.kotlin.sdk.types.Tool
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+
+/** One editable control derived from a tool's MCP input schema. */
+data class ToolParameterField(
+    val name: String,
+    val description: String?,
+    val required: Boolean,
+    val kind: Kind,
+) {
+    sealed interface Kind {
+        data object Text : Kind
+        data object Number : Kind
+        data object Bool : Kind
+        data class Choice(val options: List<String>) : Kind
+
+        /** Arrays and nested objects, which have no single sensible control — edited as JSON. */
+        data object Json : Kind
+    }
+}
+
+/**
+ * Derives the form controls for this tool. Unknown or compound types fall back to
+ * [ToolParameterField.Kind.Json] so every tool stays bindable, however exotic its schema.
+ */
+fun Tool.parameterFields(): List<ToolParameterField> {
+    val requiredNames = inputSchema.required.orEmpty().toSet()
+    val properties = inputSchema.properties ?: return emptyList()
+    return properties.map { (name, element) ->
+        val schema = element.jsonObject
+        val enumOptions = (schema["enum"] as? JsonArray)
+            ?.mapNotNull { (it as? JsonPrimitive)?.contentOrNull }
+            ?.takeIf { it.isNotEmpty() }
+        val kind = when {
+            enumOptions != null -> ToolParameterField.Kind.Choice(enumOptions)
+            else -> when ((schema["type"] as? JsonPrimitive)?.contentOrNull) {
+                "string" -> ToolParameterField.Kind.Text
+                "number", "integer" -> ToolParameterField.Kind.Number
+                "boolean" -> ToolParameterField.Kind.Bool
+                else -> ToolParameterField.Kind.Json
+            }
+        }
+        ToolParameterField(
+            name = name,
+            description = (schema["description"] as? JsonPrimitive)?.contentOrNull,
+            required = name in requiredNames,
+            kind = kind,
+        )
+    }
+}
+
+/** Required fields the user has left blank. */
+fun missingRequired(
+    fields: List<ToolParameterField>,
+    values: Map<String, String>,
+): List<String> = fields
+    .filter { it.required && values[it.name].isNullOrBlank() }
+    .map { it.name }
+
+/** JSON-typed fields whose current text does not parse. */
+fun invalidJsonFields(
+    fields: List<ToolParameterField>,
+    values: Map<String, String>,
+): List<String> = fields
+    .filter { it.kind is ToolParameterField.Kind.Json }
+    .filter { field ->
+        val raw = values[field.name]?.trim().orEmpty()
+        raw.isNotEmpty() && runCatching { Json.parseToJsonElement(raw) }.isFailure
+    }
+    .map { it.name }
+
+/**
+ * Encodes form text back into the arguments object the tool is called with. Blank values are
+ * omitted rather than sent as empty strings, so optional parameters stay absent.
+ */
+fun buildArguments(
+    fields: List<ToolParameterField>,
+    values: Map<String, String>,
+): JsonObject = buildJsonObject {
+    for (field in fields) {
+        val raw = values[field.name]?.trim().orEmpty()
+        if (raw.isEmpty()) continue
+        val encoded = when (field.kind) {
+            is ToolParameterField.Kind.Text, is ToolParameterField.Kind.Choice ->
+                JsonPrimitive(raw)
+            is ToolParameterField.Kind.Number ->
+                raw.toLongOrNull()?.let { JsonPrimitive(it) }
+                    ?: raw.toDoubleOrNull()?.let { JsonPrimitive(it) }
+                    ?: JsonPrimitive(raw)
+            is ToolParameterField.Kind.Bool ->
+                JsonPrimitive(raw.equals("true", ignoreCase = true))
+            is ToolParameterField.Kind.Json ->
+                runCatching { Json.parseToJsonElement(raw) }.getOrElse { JsonPrimitive(raw) }
+        }
+        put(field.name, encoded)
+    }
+}
+
+/**
+ * Decodes stored arguments back into form text for editing. Arguments whose parameter no longer
+ * exists in the schema are dropped — the tool would reject them anyway.
+ */
+fun JsonObject.toFormValues(fields: List<ToolParameterField>): Map<String, String> =
+    fields.mapNotNull { field ->
+        val element = this[field.name] ?: return@mapNotNull null
+        val text = when (field.kind) {
+            is ToolParameterField.Kind.Json -> element.toString()
+            else -> (element as? JsonPrimitive)?.contentOrNull ?: element.toString()
+        }
+        field.name to text
+    }.toMap()

--- a/experimental/src/commonMain/kotlin/coredevices/ring/ui/viewmodel/SettingsViewModel.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/ui/viewmodel/SettingsViewModel.kt
@@ -107,6 +107,7 @@ class SettingsViewModel(
     private val ringDelegate: RingDelegate,
     private val cactusModelProvider: CactusModelProvider,
     private val appScope: LibIndexCoroutineScope,
+    clickActionRepository: coredevices.ring.database.room.repository.ClickActionRepository,
 ): ViewModel() {
     val version = CommonBuildKonfig.GIT_HASH
     val username = Firebase.auth.authStateChanged
@@ -115,6 +116,8 @@ class SettingsViewModel(
     val userId = Firebase.auth.authStateChanged
         .map { it?.uid }
         .stateIn(viewModelScope, SharingStarted.Lazily, Firebase.auth.currentUser?.uid)
+    val clickActionBindings = clickActionRepository.bindingsFlow()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
     val llmMode = preferences.llmMode
     private val _showLlmModeDialog = MutableStateFlow(false)
     val showLlmModeDialog = _showLlmModeDialog.asStateFlow()

--- a/experimental/src/commonMain/kotlin/coredevices/ring/viewmodelModule.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/viewmodelModule.kt
@@ -2,6 +2,7 @@ package coredevices.ring
 
 import coredevices.ring.external.indexwebhook.IndexWebhookSettingsViewModel
 import coredevices.ring.ui.components.recording.RecordingTraceTimelineViewModel
+import coredevices.ring.ui.screens.settings.clickactions.ClickActionsViewModel
 import coredevices.ring.ui.screens.settings.mcp.McpSandboxGroupsViewModel
 import coredevices.ring.ui.viewmodel.AllAnswersViewModel
 import coredevices.ring.ui.viewmodel.AllListsViewModel
@@ -27,5 +28,6 @@ internal val viewmodelModule = module {
     viewModelOf(::ListenDialogViewModel)
     viewModelOf(::IndexWebhookSettingsViewModel)
     viewModelOf(::McpSandboxGroupsViewModel)
+    viewModelOf(::ClickActionsViewModel)
     viewModelOf(::RecordingTraceTimelineViewModel)
 }

--- a/experimental/src/commonTest/kotlin/coredevices/ring/database/room/repository/ClickActionRepositoryTest.kt
+++ b/experimental/src/commonTest/kotlin/coredevices/ring/database/room/repository/ClickActionRepositoryTest.kt
@@ -1,0 +1,137 @@
+package coredevices.ring.database.room.repository
+
+import coredevices.ring.data.entity.room.ClickAction
+import coredevices.ring.data.entity.room.ClickActionBinding
+import coredevices.ring.database.room.dao.ClickActionBindingDao
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+private class FakeClickActionBindingDao : ClickActionBindingDao {
+    val rows = MutableStateFlow<List<ClickActionBinding>>(emptyList())
+    private var nextId = 1L
+
+    /** Set to have the next write fail, standing in for the unique-index constraint. */
+    var failNextWrite: Throwable? = null
+
+    override fun getAllFlow(): Flow<List<ClickActionBinding>> =
+        rows.map { list -> list.sortedBy { it.clickCount } }
+
+    override suspend fun getEnabledByClickCount(clickCount: Int): ClickActionBinding? =
+        rows.value.firstOrNull { it.clickCount == clickCount && it.enabled }
+
+    override suspend fun getByClickCount(clickCount: Int): ClickActionBinding? =
+        rows.value.firstOrNull { it.clickCount == clickCount }
+
+    override suspend fun insert(binding: ClickActionBinding): Long {
+        failNextWrite?.let { failNextWrite = null; throw it }
+        val id = nextId++
+        rows.value = rows.value + binding.copy(id = id)
+        return id
+    }
+
+    override suspend fun update(binding: ClickActionBinding) {
+        failNextWrite?.let { failNextWrite = null; throw it }
+        rows.value = rows.value.map { if (it.id == binding.id) binding else it }
+    }
+
+    override suspend fun delete(id: Long) {
+        rows.value = rows.value.filterNot { it.id == id }
+    }
+}
+
+class ClickActionRepositoryTest {
+
+    private fun binding(clickCount: Int, id: Long = 0L, enabled: Boolean = true) =
+        ClickActionBinding(
+            id = id,
+            clickCount = clickCount,
+            action = ClickAction.AgentText("test"),
+            enabled = enabled,
+        )
+
+    @Test
+    fun `saving a new binding assigns an id`() = runTest {
+        val repo = ClickActionRepository(FakeClickActionBindingDao())
+
+        val result = repo.save(binding(clickCount = 4))
+
+        assertEquals(ClickActionRepository.SaveResult.Saved(1L), result)
+    }
+
+    @Test
+    fun `a click count owned by another binding is rejected`() = runTest {
+        val repo = ClickActionRepository(FakeClickActionBindingDao())
+        repo.save(binding(clickCount = 4))
+
+        val result = repo.save(binding(clickCount = 4))
+
+        assertEquals(ClickActionRepository.SaveResult.ClickCountTaken, result)
+    }
+
+    @Test
+    fun `a binding may keep its own click count when edited`() = runTest {
+        val dao = FakeClickActionBindingDao()
+        val repo = ClickActionRepository(dao)
+        repo.save(binding(clickCount = 4))
+
+        val result = repo.save(
+            ClickActionBinding(id = 1L, clickCount = 4, action = ClickAction.AgentText("hi")),
+        )
+
+        assertEquals(ClickActionRepository.SaveResult.Saved(1L), result)
+        assertEquals(ClickAction.AgentText("hi"), dao.getByClickCount(4)?.action)
+    }
+
+    @Test
+    fun `click counts outside the bindable range are rejected`() = runTest {
+        val repo = ClickActionRepository(FakeClickActionBindingDao())
+
+        assertEquals(
+            ClickActionRepository.SaveResult.ClickCountOutOfRange,
+            repo.save(binding(clickCount = ClickActionBinding.MIN_CLICK_COUNT - 1)),
+        )
+        assertEquals(
+            ClickActionRepository.SaveResult.ClickCountOutOfRange,
+            repo.save(binding(clickCount = ClickActionBinding.MAX_CLICK_COUNT + 1)),
+        )
+    }
+
+    @Test
+    fun `a write that loses the unique-index race is reported, not thrown`() = runTest {
+        val dao = FakeClickActionBindingDao()
+        val repo = ClickActionRepository(dao)
+        dao.failNextWrite = IllegalStateException("UNIQUE constraint failed")
+
+        val result = repo.save(binding(clickCount = 4))
+
+        assertTrue(result is ClickActionRepository.SaveResult.Failed)
+        assertEquals("UNIQUE constraint failed", result.message)
+    }
+
+    @Test
+    fun `only enabled bindings are dispatchable`() = runTest {
+        val repo = ClickActionRepository(FakeClickActionBindingDao())
+        repo.save(binding(clickCount = 4, enabled = false))
+
+        assertNull(repo.enabledBindingFor(4))
+    }
+
+    @Test
+    fun `deleting frees the click count`() = runTest {
+        val repo = ClickActionRepository(FakeClickActionBindingDao())
+        val saved = repo.save(binding(clickCount = 4)) as ClickActionRepository.SaveResult.Saved
+
+        repo.delete(saved.id)
+
+        assertEquals(
+            ClickActionRepository.SaveResult.Saved(2L),
+            repo.save(binding(clickCount = 4)),
+        )
+    }
+}

--- a/experimental/src/commonTest/kotlin/coredevices/ring/service/ButtonDispatchTest.kt
+++ b/experimental/src/commonTest/kotlin/coredevices/ring/service/ButtonDispatchTest.kt
@@ -1,0 +1,69 @@
+package coredevices.ring.service
+
+import coredevices.ring.database.MusicControlMode
+import coredevices.ring.database.reservedClickCounts
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ButtonDispatchTest {
+
+    private fun shorts(n: Int) = List(n) { ButtonPress.Short }
+
+    @Test
+    fun `a sequence containing a long press belongs to the recording pipeline`() {
+        // Press-and-hold, and click-then-hold — both start recordings.
+        assertEquals(
+            ButtonDispatch.Ignore,
+            resolveButtonDispatch(listOf(ButtonPress.Long), emptySet()),
+        )
+        assertEquals(
+            ButtonDispatch.Ignore,
+            resolveButtonDispatch(listOf(ButtonPress.Short, ButtonPress.Long), emptySet()),
+        )
+    }
+
+    @Test
+    fun `an empty sequence is ignored`() {
+        assertEquals(ButtonDispatch.Ignore, resolveButtonDispatch(emptyList(), emptySet()))
+    }
+
+    @Test
+    fun `media control wins over a custom binding on the same count`() {
+        val reserved = MusicControlMode.DoubleClick.reservedClickCounts()
+
+        assertEquals(ButtonDispatch.Media(shorts(2)), resolveButtonDispatch(shorts(2), reserved))
+        assertEquals(ButtonDispatch.Media(shorts(3)), resolveButtonDispatch(shorts(3), reserved))
+    }
+
+    @Test
+    fun `counts media control does not claim go to the custom binding`() {
+        val reserved = MusicControlMode.DoubleClick.reservedClickCounts()
+
+        assertEquals(ButtonDispatch.Custom(1), resolveButtonDispatch(shorts(1), reserved))
+        assertEquals(ButtonDispatch.Custom(4), resolveButtonDispatch(shorts(4), reserved))
+    }
+
+    @Test
+    fun `with media control disabled every count is custom`() {
+        val reserved = MusicControlMode.Disabled.reservedClickCounts()
+
+        (1..8).forEach { count ->
+            assertEquals(ButtonDispatch.Custom(count), resolveButtonDispatch(shorts(count), reserved))
+        }
+    }
+
+    @Test
+    fun `single click mode claims one and two clicks`() {
+        val reserved = MusicControlMode.SingleClick.reservedClickCounts()
+
+        assertEquals(ButtonDispatch.Media(shorts(1)), resolveButtonDispatch(shorts(1), reserved))
+        assertEquals(ButtonDispatch.Media(shorts(2)), resolveButtonDispatch(shorts(2), reserved))
+        assertEquals(ButtonDispatch.Custom(3), resolveButtonDispatch(shorts(3), reserved))
+    }
+
+    @Test
+    fun `counts beyond the bindable range are ignored`() {
+        assertEquals(ButtonDispatch.Ignore, resolveButtonDispatch(shorts(9), emptySet()))
+        assertEquals(ButtonDispatch.Ignore, resolveButtonDispatch(shorts(20), emptySet()))
+    }
+}

--- a/experimental/src/commonTest/kotlin/coredevices/ring/ui/screens/settings/clickactions/ClickActionCountsTest.kt
+++ b/experimental/src/commonTest/kotlin/coredevices/ring/ui/screens/settings/clickactions/ClickActionCountsTest.kt
@@ -1,0 +1,86 @@
+package coredevices.ring.ui.screens.settings.clickactions
+
+import coredevices.ring.data.entity.room.ClickAction
+import coredevices.ring.data.entity.room.ClickActionBinding
+import coredevices.ring.database.MusicControlMode
+import coredevices.ring.database.reservedClickCounts
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class ClickActionCountsTest {
+
+    private fun binding(id: Long, clickCount: Int) = ClickActionBinding(
+        id = id,
+        clickCount = clickCount,
+        action = ClickAction.AgentText("test"),
+    )
+
+    private fun options(
+        existing: List<ClickActionBinding> = emptyList(),
+        reserved: Set<Int> = emptySet(),
+        editingId: Long = 0L,
+    ) = clickCountOptions(existing, reserved, editingId)
+
+    private fun List<ClickCountOption>.counts(availability: ClickCountAvailability) =
+        filter { it.availability == availability }.map { it.count }
+
+    @Test
+    fun `media control reserves the counts its gestures use`() {
+        assertEquals(emptySet(), MusicControlMode.Disabled.reservedClickCounts())
+        assertEquals(setOf(1, 2), MusicControlMode.SingleClick.reservedClickCounts())
+        assertEquals(setOf(2, 3), MusicControlMode.DoubleClick.reservedClickCounts())
+    }
+
+    @Test
+    fun `every count in range is offered`() {
+        assertEquals((1..8).toList(), options().map { it.count })
+    }
+
+    @Test
+    fun `all counts are available when nothing is bound or reserved`() {
+        assertEquals((1..8).toList(), options().counts(ClickCountAvailability.Available))
+    }
+
+    @Test
+    fun `media-reserved counts are shown but not selectable`() {
+        val result = options(reserved = MusicControlMode.DoubleClick.reservedClickCounts())
+
+        assertEquals(listOf(2, 3), result.counts(ClickCountAvailability.UsedByMediaControl))
+        assertEquals(listOf(1, 4, 5, 6, 7, 8), result.counts(ClickCountAvailability.Available))
+    }
+
+    @Test
+    fun `counts owned by another binding are shown but not selectable`() {
+        val result = options(existing = listOf(binding(id = 1, clickCount = 3)))
+
+        assertEquals(listOf(3), result.counts(ClickCountAvailability.UsedByAnotherAction))
+        assertEquals(listOf(1, 2, 4, 5, 6, 7, 8), result.counts(ClickCountAvailability.Available))
+    }
+
+    @Test
+    fun `a binding being edited keeps its own count selectable`() {
+        val result = options(
+            existing = listOf(binding(id = 7, clickCount = 3), binding(id = 8, clickCount = 4)),
+            editingId = 7L,
+        )
+
+        assertEquals(listOf(4), result.counts(ClickCountAvailability.UsedByAnotherAction))
+        assertEquals(listOf(1, 2, 3, 5, 6, 7, 8), result.counts(ClickCountAvailability.Available))
+    }
+
+    @Test
+    fun `media control takes precedence over an existing binding on the same count`() {
+        // Media control dispatches first, so that is the reason worth showing the user.
+        val result = options(existing = listOf(binding(id = 1, clickCount = 2)), reserved = setOf(2))
+
+        assertEquals(listOf(2), result.counts(ClickCountAvailability.UsedByMediaControl))
+        assertEquals(emptyList(), result.counts(ClickCountAvailability.UsedByAnotherAction))
+    }
+
+    @Test
+    fun `firstSelectable skips locked counts`() {
+        assertEquals(3, options(reserved = setOf(1, 2)).firstSelectable())
+        assertNull(options(reserved = (1..8).toSet()).firstSelectable())
+    }
+}

--- a/experimental/src/commonTest/kotlin/coredevices/ring/ui/screens/settings/clickactions/ToolParameterSchemaTest.kt
+++ b/experimental/src/commonTest/kotlin/coredevices/ring/ui/screens/settings/clickactions/ToolParameterSchemaTest.kt
@@ -1,0 +1,173 @@
+package coredevices.ring.ui.screens.settings.clickactions
+
+import io.modelcontextprotocol.kotlin.sdk.types.Tool
+import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ToolParameterSchemaTest {
+
+    private fun tool(properties: JsonObject, required: List<String> = emptyList()) = Tool(
+        name = "test_tool",
+        description = "A test tool",
+        inputSchema = ToolSchema(properties = properties, required = required),
+    )
+
+    private val kitchenSink = tool(
+        properties = buildJsonObject {
+            put("room", buildJsonObject {
+                put("type", "string")
+                put("description", "Which room")
+            })
+            put("brightness", buildJsonObject { put("type", "integer") })
+            put("fade", buildJsonObject { put("type", "number") })
+            put("on", buildJsonObject { put("type", "boolean") })
+            put("mode", buildJsonObject {
+                put("type", "string")
+                put("enum", buildJsonArray {
+                    add(JsonPrimitive("warm"))
+                    add(JsonPrimitive("cool"))
+                })
+            })
+            put("scenes", buildJsonObject { put("type", "array") })
+        },
+        required = listOf("room", "on"),
+    )
+
+    @Test
+    fun `maps schema types to field kinds`() {
+        val byName = kitchenSink.parameterFields().associateBy { it.name }
+
+        assertEquals(ToolParameterField.Kind.Text, byName.getValue("room").kind)
+        assertEquals(ToolParameterField.Kind.Number, byName.getValue("brightness").kind)
+        assertEquals(ToolParameterField.Kind.Number, byName.getValue("fade").kind)
+        assertEquals(ToolParameterField.Kind.Bool, byName.getValue("on").kind)
+        assertEquals(
+            ToolParameterField.Kind.Choice(listOf("warm", "cool")),
+            byName.getValue("mode").kind,
+        )
+        // Arrays have no single control, so they fall back to raw JSON rather than
+        // making the tool unbindable.
+        assertEquals(ToolParameterField.Kind.Json, byName.getValue("scenes").kind)
+    }
+
+    @Test
+    fun `carries description and required flag`() {
+        val byName = kitchenSink.parameterFields().associateBy { it.name }
+
+        assertEquals("Which room", byName.getValue("room").description)
+        assertTrue(byName.getValue("room").required)
+        assertTrue(byName.getValue("on").required)
+        assertTrue(!byName.getValue("brightness").required)
+    }
+
+    @Test
+    fun `tool with no properties has no fields`() {
+        assertEquals(emptyList(), tool(properties = JsonObject(emptyMap())).parameterFields())
+    }
+
+    @Test
+    fun `buildArguments coerces each kind to its json type`() {
+        val args = buildArguments(
+            kitchenSink.parameterFields(),
+            mapOf(
+                "room" to "office",
+                "brightness" to "80",
+                "fade" to "1.5",
+                "on" to "true",
+                "mode" to "warm",
+                "scenes" to """["evening"]""",
+            ),
+        )
+
+        assertEquals("office", args.getValue("room").jsonPrimitive.content)
+        assertEquals("80", args.getValue("brightness").jsonPrimitive.content)
+        assertEquals(false, args.getValue("brightness").jsonPrimitive.isString)
+        assertEquals("1.5", args.getValue("fade").jsonPrimitive.content)
+        assertEquals(true, args.getValue("on").jsonPrimitive.content.toBoolean())
+        assertEquals(false, args.getValue("on").jsonPrimitive.isString)
+        assertEquals("warm", args.getValue("mode").jsonPrimitive.content)
+        assertEquals("""["evening"]""", args.getValue("scenes").toString())
+    }
+
+    @Test
+    fun `buildArguments omits blank values so optional params stay absent`() {
+        val args = buildArguments(
+            kitchenSink.parameterFields(),
+            mapOf("room" to "office", "brightness" to "   ", "mode" to ""),
+        )
+
+        assertEquals(setOf("room"), args.keys)
+    }
+
+    @Test
+    fun `unparseable number falls back to a string rather than dropping the value`() {
+        val args = buildArguments(kitchenSink.parameterFields(), mapOf("brightness" to "bright"))
+
+        assertEquals("bright", args.getValue("brightness").jsonPrimitive.content)
+        assertEquals(true, args.getValue("brightness").jsonPrimitive.isString)
+    }
+
+    @Test
+    fun `missingRequired reports only blank required fields`() {
+        assertEquals(
+            listOf("room", "on"),
+            missingRequired(kitchenSink.parameterFields(), emptyMap()),
+        )
+        assertEquals(
+            listOf("on"),
+            missingRequired(kitchenSink.parameterFields(), mapOf("room" to "office")),
+        )
+        assertEquals(
+            emptyList(),
+            missingRequired(
+                kitchenSink.parameterFields(),
+                mapOf("room" to "office", "on" to "true"),
+            ),
+        )
+    }
+
+    @Test
+    fun `invalidJsonFields flags only unparseable json`() {
+        val fields = kitchenSink.parameterFields()
+
+        assertEquals(listOf("scenes"), invalidJsonFields(fields, mapOf("scenes" to "[unclosed")))
+        assertEquals(emptyList(), invalidJsonFields(fields, mapOf("scenes" to """["ok"]""")))
+        // Blank is absent, not invalid.
+        assertEquals(emptyList(), invalidJsonFields(fields, mapOf("scenes" to "  ")))
+    }
+
+    @Test
+    fun `stored arguments round trip back into form values`() {
+        val fields = kitchenSink.parameterFields()
+        val original = mapOf(
+            "room" to "office",
+            "brightness" to "80",
+            "on" to "true",
+            "mode" to "cool",
+            "scenes" to """["evening"]""",
+        )
+
+        assertEquals(original, buildArguments(fields, original).toFormValues(fields))
+    }
+
+    @Test
+    fun `arguments for parameters no longer in the schema are dropped`() {
+        val fields = tool(
+            properties = buildJsonObject { put("room", buildJsonObject { put("type", "string") }) }
+        ).parameterFields()
+        val stored = buildJsonObject {
+            put("room", "office")
+            put("removed_param", "stale")
+        }
+
+        assertEquals(mapOf("room" to "office"), stored.toFormValues(fields))
+    }
+}


### PR DESCRIPTION
Part 3 of 3. **Stacked on #328 — please review #327 and #328 first.**

> Until the earlier parts merge, GitHub shows this diff against `master`, so it includes their commits. Review only `Index: let a click action call the configured webhook`. I'll rebase as they land.

## What this does

Adds the third click action: ping the configured Index webhook. There's no audio or transcript behind a click, so the request carries metadata only.

## Design notes for review

**`IndexWebhookRecordingTrigger` becomes a sealed interface.** It needs to carry a click count alongside the two fixed recording gestures, which an enum can't do. The header value is `"<n>-clicks"`, so a receiver can tell which binding fired it — without that, every click action looks identical on the wire. Existing call sites reference the two data objects and are unchanged, as is `IndexWebhookRecordingTriggerTest`.

**`IndexWebhookPreferences.trigger` is deliberately not consulted.** That setting picks which *recording* gesture uploads. A click binding is itself the user's explicit opt-in, so there's nothing further to gate. Flagging it because it's a visible divergence from `RecordingOperationFactory.maybeWrapWithWebhook` and I'd rather you disagree with it explicitly than miss it.

## Testing

- 212 unit tests pass, including the existing `IndexWebhookRecordingTriggerTest` unchanged through the enum→sealed conversion.
- Webhook delivery itself was **not** exercised against a live endpoint — I had no server to point it at. The other two actions were verified on hardware.
- iOS not built (no macOS); `commonMain` only.

## Known follow-ups (all three parts)

Not fixed here, noted so they're not lost:

- A binding whose count is later claimed by media control stays saved but stops firing. The list marks it, but nothing prompts the user to re-bind.
- Deleting every MCP sandbox group makes `getDefaultGroupId()` throw; click actions then no-op. Pre-existing fragility this feature now depends on.
- A disabled binding still reserves its click count. Defensible — it owns the slot — but possibly surprising.

## AI assistance

This change was written with AI assistance. I have reviewed the implementation, understand it, and tested it on hardware.
