### PR TITLE
Fix the status bar notification icon showing as a plain circle

### DIFF
--- a/composeApp/src/androidMain/kotlin/coredevices/coreapp/PebbleService.kt
+++ b/composeApp/src/androidMain/kotlin/coredevices/coreapp/PebbleService.kt
@@ -132,7 +132,7 @@ class PebbleService: Service(), KoinComponent {
             .setContentTitle("Pebble")
             .setContentText("Keeping Pebble connection alive")
             .setOngoing(true)
-            .setSmallIcon(R.mipmap.ic_launcher)
+            .setSmallIcon(R.drawable.ic_notification)
             .setContentIntent(contentIntent)
             .build()
         try {

--- a/composeApp/src/androidMain/kotlin/coredevices/coreapp/api/BugReports.android.kt
+++ b/composeApp/src/androidMain/kotlin/coredevices/coreapp/api/BugReports.android.kt
@@ -43,7 +43,7 @@ actual fun createNotification(
 
     platformContext.context.createChannel()
     val builder = NotificationCompat.Builder(platformContext.context, CHANNEL_ID)
-        .setSmallIcon(R.mipmap.ic_launcher)
+        .setSmallIcon(R.drawable.ic_notification)
         .setContentTitle("Pebble Support message")
         .setContentText(message)
         .setPriority(NotificationCompat.PRIORITY_DEFAULT)

--- a/pebble/src/androidMain/kotlin/coredevices/pebble/firmware/BatteryFullyChargedNotification.android.kt
+++ b/pebble/src/androidMain/kotlin/coredevices/pebble/firmware/BatteryFullyChargedNotification.android.kt
@@ -22,7 +22,7 @@ actual fun postWatchFullyChargedNotification(appContext: AppContext, watchName: 
         PendingIntent.FLAG_IMMUTABLE
     )
     val builder = NotificationCompat.Builder(context, BATTERY_CHANNEL_ID)
-        .setSmallIcon(R.mipmap.ic_launcher)
+        .setSmallIcon(R.drawable.ic_notification)
         .setContentTitle("Watch Fully Charged")
         .setContentText("$watchName is fully charged")
         .setPriority(NotificationCompat.PRIORITY_DEFAULT)

--- a/pebble/src/androidMain/kotlin/coredevices/pebble/firmware/FirmwareUpdateUiTracker.android.kt
+++ b/pebble/src/androidMain/kotlin/coredevices/pebble/firmware/FirmwareUpdateUiTracker.android.kt
@@ -60,7 +60,7 @@ actual fun notifyFirmwareUpdate(
         context,
         CHANNEL_ID,
     )
-        .setSmallIcon(R.mipmap.ic_launcher)
+        .setSmallIcon(R.drawable.ic_notification)
         .setContentTitle(title)
         .setContentText(body)
         .setPriority(NotificationCompat.PRIORITY_DEFAULT)

--- a/util/src/androidMain/kotlin/AppUpdate.android.kt
+++ b/util/src/androidMain/kotlin/AppUpdate.android.kt
@@ -133,7 +133,7 @@ class AndroidAppUpdate(
 
         context.createChannel()
         val builder = NotificationCompat.Builder(context, CHANNEL_ID)
-            .setSmallIcon(R.mipmap.ic_launcher)
+            .setSmallIcon(R.drawable.ic_notification)
             .setContentTitle("Pebble App Update Available")
             .setContentText("Please update the Pebble app!")
             .setPriority(NotificationCompat.PRIORITY_DEFAULT)

--- a/util/src/androidMain/res/drawable/ic_notification.xml
+++ b/util/src/androidMain/res/drawable/ic_notification.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:pathData="M 4.24,11.85 A 6.47,6.47 0 1 1 17.18,11.85 A 6.47,6.47 0 1 1 4.24,11.85"
+        android:strokeColor="#FFFFFFFF"
+        android:strokeWidth="1.6" />
+    <path
+        android:pathData="M 17.19,4.01 A 1.36,1.36 0 1 1 19.91,4.01 A 1.36,1.36 0 1 1 17.19,4.01"
+        android:strokeColor="#FFFFFFFF"
+        android:strokeWidth="1.3" />
+    <path
+        android:pathData="M 9.35,21.74 L 12.08,21.74"
+        android:strokeColor="#FFFFFFFF"
+        android:strokeWidth="1.3"
+        android:strokeLineCap="round" />
+</vector>


### PR DESCRIPTION
Notifications used the app's launcher icon as their small icon. Android keeps only the alpha channel of a small icon, and the launcher art is opaque everywhere, so the status bar showed a plain disc with no detail in it.

Before:

![Status bar showing a featureless white disc](https://github.com/adipascu/mobileapp/releases/download/pr-assets/notification-icon-before.png)

After:

![Status bar showing the logo silhouette](https://github.com/adipascu/mobileapp/releases/download/pr-assets/notification-icon-after.png)

A monochrome silhouette of the logo, drawn as a small vector, replaces the launcher icon at every notification call site, including the always-visible connection notification. Nothing else changes.

Written with AI assistance (Claude), and captured on a Pixel 6.

---

Aside: I am currently available for mobile or firmware contracting or full-time work. Contact: adrian@pascu.be.
