### PR TITLE
Match the notification icon geometry to the launcher art

### DIFF
--- a/util/src/androidMain/res/drawable/ic_notification.xml
+++ b/util/src/androidMain/res/drawable/ic_notification.xml
@@ -5,16 +5,16 @@
     android:viewportWidth="24"
     android:viewportHeight="24">
     <path
-        android:pathData="M 4.24,11.85 A 6.47,6.47 0 1 1 17.18,11.85 A 6.47,6.47 0 1 1 4.24,11.85"
+        android:pathData="M 2.435,11.820 A 8.150,8.150 0 1 1 18.735,11.820 A 8.150,8.150 0 1 1 2.435,11.820"
         android:strokeColor="#FFFFFFFF"
-        android:strokeWidth="1.6" />
+        android:strokeWidth="1.68" />
     <path
-        android:pathData="M 17.19,4.01 A 1.36,1.36 0 1 1 19.91,4.01 A 1.36,1.36 0 1 1 17.19,4.01"
+        android:pathData="M 17.551,2.848 A 2.007,2.007 0 1 1 21.565,2.848 A 2.007,2.007 0 1 1 17.551,2.848"
         android:strokeColor="#FFFFFFFF"
-        android:strokeWidth="1.3" />
+        android:strokeWidth="1.68" />
     <path
-        android:pathData="M 9.35,21.74 L 12.08,21.74"
+        android:pathData="M 9.175,23.160 L 11.994,23.160"
         android:strokeColor="#FFFFFFFF"
-        android:strokeWidth="1.3"
+        android:strokeWidth="1.68"
         android:strokeLineCap="round" />
 </vector>


### PR DESCRIPTION
Follow-up to #338. The notification silhouette there was drawn by hand from the launcher art, and its proportions were close but not exact. This replaces the numbers with geometry fitted to the 512 px launcher icon, so the status bar mark now matches the art precisely.

- The fit found the mark uses one uniform stroke for all three shapes, places the small circle exactly on the 45 degree diagonal, and centers the dash exactly under the ring
- Against those numbers the hand-drawn version had the small circle about 22 percent too small and the ring 4 percent too small

Small heads up: #338 was merged straight out of draft, so this refinement, which was still being polished there, arrives as its own PR instead.

| Stage | Image |
|---|---|
| **Reference** <br> the 512 px launcher art the geometry was fitted to | ![Pebble launcher art](https://github.com/adipascu/mobileapp/releases/download/pr-assets/pebble-launcher-art.png) |
| **Before the icon fix** <br> the launcher icon masked to a featureless disc | ![Status bar with a plain disc](https://github.com/adipascu/mobileapp/releases/download/pr-assets/notification-icon3-before.png) |
| **Draft #338 as merged** <br> the hand-drawn silhouette | ![Status bar with the hand-drawn icon](https://github.com/adipascu/mobileapp/releases/download/pr-assets/notification-icon3-merged.png) |
| **Current PR** <br> geometry fitted to the launcher art | ![Status bar with the fitted icon](https://github.com/adipascu/mobileapp/releases/download/pr-assets/notification-icon3-fitted.png) |

Written with AI assistance (Claude), and captured on a Pixel 6.

---

Aside: I am currently available for mobile or firmware contracting or full-time work. Contact: adrian@pascu.be.
